### PR TITLE
Refactored TestObject API to remove mocha before/after

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ import { stubEnv } from './lib/env-utils.js';
 import { stubLog } from './lib/log-utils.js';
 import { fakeTime } from './lib/time-utils.js';
 import { withSandbox, withMocks, verify } from './lib/sandox-utils.js';
-import { usingTestObject, addTestObjectMochaHooks, getTestObjectCaps } from './lib/testobject.js';
+import { enableTestObject, disableTestObject } from './lib/testobject.js';
 
 export { stubEnv, stubLog, fakeTime, withSandbox, withMocks, verify, 
-  usingTestObject, addTestObjectMochaHooks, getTestObjectCaps };
+  enableTestObject, disableTestObject };

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -11,13 +11,13 @@ let s3 = new AWS.S3({
   },
 });
 
-
+const S3 = {};
 
 /**
  * Zips a local directory and uploads it to S3
  * @param {*} localDir 
  */
-async function uploadZip (localDir) {
+S3.uploadZip = async function (localDir) {
   if (!process.env.AWS_S3_BUCKET) {
     throw new Error('To use S3, you must specify AWS_S3_BUCKET in environment variables');
   }
@@ -44,12 +44,12 @@ async function uploadZip (localDir) {
       Body: base64Zip,
     }, (err, res) => err ? reject(new Error(`Could not upload ${localDir} to S3. Check that you have set the S3 environment variables correctly: ${err}`)) : resolve(res));
   });
-}
+};
 
 /**
  * Deletes a file at given URL
  */
-async function deleteZip (key) {
+S3.deleteZip = async function (key) {
   if (!process.env.AWS_S3_BUCKET) {
     throw new Error('To use S3, you must specify AWS_S3_BUCKET in environment variables');
   }
@@ -59,7 +59,6 @@ async function deleteZip (key) {
       Key: key,
     }, (err, res) => err ? reject(new Error(`Could not delete zip ${key}: ${err}`)) : resolve(res));
   });
-}
+};
 
-export {uploadZip, deleteZip};
-export default {uploadZip, deleteZip};
+export default S3;

--- a/lib/testobject.js
+++ b/lib/testobject.js
@@ -1,7 +1,7 @@
-import zip from './s3';
+import S3 from './s3';
 import { exec } from 'teen_process';
 import { fs } from 'appium-support';
-import log from '../lib/logger';
+import logger from '../lib/logger';
 import _ from 'lodash';
 
 const TestObject = {};
@@ -85,8 +85,9 @@ TestObject.uploadTestObjectApp = async function (app) {
     };
     return appId;
   } catch (e) {
-    console.error(`Could not upload ${app} to TestObject. Log into https://app.staging.testobject.org/ and verify that ${app} has been uploaded manually. 
+    logger.error(`Could not upload ${app} to TestObject. Log into https://app.staging.testobject.org/ and verify that ${app} has been uploaded manually. 
       The API call to /api/storage/upload re-uploads apps. It doesn't upload them the first time: (${e})`);
+    throw e;
   }
 };
 
@@ -117,6 +118,7 @@ TestObject.overrideWD = function (wd, appiumZipUrl) {
     const originalInit = driver.init;
     driver.init = async function (caps, ...args) {
       const extendedCaps = await TestObject.getTestObjectCaps(caps);
+      logger.debug(`Setting caps.testobject_remote_appium_url to ${appiumZipUrl}`);
       extendedCaps.testobject_remote_appium_url = appiumZipUrl;
       return await originalInit.call(driver, extendedCaps, ...args);
     };
@@ -133,54 +135,36 @@ TestObject.restoreWD = function (wd, originalPromiseChainRemote) {
   wd.promiseChainRemote = originalPromiseChainRemote;
 };
 
+
 /**
- * Adds before/after hooks to mocha
- * 
- * Uploads 
- * 
+ * Uploads zip to S3 and overrides WD to use TO objects
  */
-TestObject.addTestObjectMochaHooks = async function (appiumDir) {
-  let appiumS3Object = await zip.uploadZip(appiumDir);
+TestObject.enableTestObject = async function (wd, appiumDir) {
+  appiumDir = appiumDir || process.env.PWD; // Default to PWD if no appium directory provided
+  logger.debug(`Uploading '${appiumDir}' to S3`);
+  let appiumS3Object;
+  try {
+    appiumS3Object = await S3.uploadZip(appiumDir);
+  } catch (e) {
+    logger.error(`Could not upload ${appiumDir} to S3. Reason: (${e.message})`);
+    throw e;
+  }
 
-  before(async function () { // jshint ignore:line
-    console.log('Setting timeout to', TestObject.MOCHA_TESTOBJECT_TIMEOUT);
-    this.timeout(TestObject.MOCHA_TESTOBJECT_TIMEOUT); // Set a long timeout because we're uploading a large file to s3
-    console.log('process.env.TESTOBJECT===true: Running tests on TestObject');
-    console.log(`Uploading ${appiumDir} to S3`);
-    console.log(`Done uploading ${appiumDir} to S3`);
-  });
-
-  after(async function () { // jshint ignore:line
-    console.log(`Deleting ${appiumDir} from S3`);
-    await zip.deleteZip(appiumS3Object.Key);
-    console.log(`Deleted ${appiumDir} from S3`);
-  });
-
-  return appiumS3Object;
+  // Overriding WD so it uses the appiumS3Object.Location
+  return {
+    wdOverride: TestObject.overrideWD(wd, appiumS3Object.Location),
+    appiumS3Object,
+    wd,
+  };
 };
 
 /**
- * Mocha 'before' and 'after' functions that upload appium directory and app to TestObject
- * and override 'wd' to point HOST and PORT to TestObject and add caps
+ * Takes the object that was returned by enableTestObject and uses it to restore WD
+ * and delete the zip from S3
  */
-TestObject.usingTestObject = function (wd, appiumDir) {
-  appiumDir = appiumDir || process.env.PWD; // Default to PWD if no appium directory provided
-  let wdOverrides;
-
-  if(!this || !this.timeout || !_.isFunction(this.timeout)) {
-    throw new Error('Method "usingTestObject" must be called with mocha context');
-  }
-  this.timeout(TestObject.MOCHA_TESTOBJECT_TIMEOUT);
-
-  const appiumS3Object = TestObject.addTestObjectMochaHooks(appiumDir);
-
-  before(async function () { // jshint ignore:line
-    wdOverrides = TestObject.overrideWD(wd, appiumS3Object.Location);
-  });
-
-  after(async function () { // jshint ignore:line
-    TestObject.restoreWD(wd, wdOverrides);
-  });
+TestObject.disableTestObject = async function ({wdOverride, appiumS3Object, wd}) {
+  TestObject.restoreWD(wd, wdOverride);
+  await S3.deleteZip(appiumS3Object.Key);
 };
 
 export default TestObject;

--- a/test/e2e/testobject-e2e-specs.js
+++ b/test/e2e/testobject-e2e-specs.js
@@ -2,31 +2,40 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import path from 'path';
 import wd from 'wd';
-import { usingTestObject, overrideWD, uploadTestObjectApp, HOST as TESTOBJECT_HOST } from '../../lib/testobject';
-import sinon from 'sinon';
+import request from 'request-promise';
+import { uploadTestObjectApp, disableTestObject, enableTestObject } from '../../lib/testobject';
 
 chai.should();
 chai.use(chaiAsPromised);
 
 describe('TestObject', function () {
+  this.timeout(20 * 60 * 1000);
   describe('#uploadTestObjectApp', function () {
     it('should upload fake app file to testObject', async function () {
       await uploadTestObjectApp(path.resolve('test', 'fixtures', 'ContactManager.apk')).should.eventually.be.resolved;
     });
   });
 
-  describe.only('#usingTestObject', function () {
-    const fakeDriverPath = path.resolve(process.env.PWD, 'node_modules', 'appium');
-    usingTestObject.call(this, wd, fakeDriverPath);
-    
-    it('should start wd session on TestObject server when using "usingTestObject" and be able to get the source of the test app', async function () {
+  describe('.enableTestObject, .disableTestObject', function () {
+    it('should enable testObject tests and then be able to disable them afterwards', async function () {
+      const wdObject = await enableTestObject(wd, path.resolve(process.env.PWD, 'node_modules', 'appium'));
+
+      // Test that the zip was uploaded
+      const location = wdObject.appiumS3Object.Location;
+      await request(location).should.eventually.be.resolved;
+
+      // Test that we can do TestObject tests
       const driver = await wd.promiseChainRemote();
       await driver.init({
         app: path.resolve('test', 'fixtures', 'ContactManager.apk'),
       });
       const source = await driver.source();
       source.should.contain('android.widget.LinearLayout');
-      return driver;
+      await driver.quit();
+
+      // Check that after we clean up, the zip file is gone
+      await disableTestObject(wdObject);
+      await request(location).should.eventually.be.rejectedWith(/403/);
     });
   });
 });


### PR DESCRIPTION
* Removed the 'usingTestObject' function which made use of mocha hooks. The mocha hooks were a bit overengineered and difficult to debug/reason-about. In it's place, implemented enableTestObject and disableTestObject
* enableTestObject uploads the appium zip and overrides WD so that it appends the TestObject specific capabilities to new Appium session (this should be called in mocha -> before)
* disableTestObject takes the object returned by enableTestObject and uses it to restore WD and delete the Zip from S3 (this should be called in mocha -> after)
* Refactored s3.js to look more look testObject.js
* Added more logging