### PR TITLE
Inject driver into Appium

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -2,6 +2,7 @@ import AWS from 'aws-sdk';
 import B from 'bluebird';
 import { zip, fs } from 'appium-support';
 import { v4 as uuid } from 'uuid';
+import logger from '../lib/logger';
 
 const Bucket = process.env.AWS_S3_BUCKET;
 
@@ -27,22 +28,26 @@ S3.uploadZip = async function (localDir) {
 
   // Attempt to zip the directory
   let base64Zip;
+  logger.debug(`Zipping ${localDir} to memory`);
   try {
     base64Zip = await zip.toInMemoryZip(localDir);
   } catch (err) {
     throw new Error(`Could not zip directory ${localDir}: ${err}`);
   }
+  logger.debug(`Done zipping ${localDir}`);
 
   // Call s3.upload and return it as a promise
   // (NOTE: B.promisify doesn't work for s3.upload, it causes s3/managed_upload.js to throw an error `self.service.constructor.__super__ is not a constructor`)
+  logger.debug(`Uploading ${localDir} to S3 ${Bucket}`);
   return await new B((resolve, reject) => {
-    s3.upload({
-      Bucket: process.env.AWS_S3_BUCKET,
+    const uploader = s3.upload({
+      Bucket,
       Key: `${uuid()}.zip`, // Give it a random name
       ACL: 'public-read',
       Expiration: 1, // Expires after one day
       Body: base64Zip,
     }, (err, res) => err ? reject(new Error(`Could not upload ${localDir} to S3. Check that you have set the S3 environment variables correctly: ${err}`)) : resolve(res));
+    uploader.on('httpUploadProgress', (progress) => logger.debug(`Uploading ${localDir} progress ${Math.round(progress.loaded / progress.total * 100 * 100) / 100}%`));
   });
 };
 

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -43,8 +43,8 @@ S3.uploadZip = async function (pathToZip) {
       } else {
         resolve(res);
       }
-      uploader.on('httpUploadProgress', (progress) => logger.debug(`Uploading ${pathToZip} progress ${Math.round(progress.loaded / progress.total * 100)}%`));
     });
+    uploader.on('httpUploadProgress', (progress) => logger.debug(`Uploading ${pathToZip} progress ${Math.round(progress.loaded / progress.total * 100)}%`));
   });
 };
 

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -29,20 +29,21 @@ S3.uploadZip = async function (pathToZip) {
   // Call s3.upload and return it as a promise
   // (NOTE: B.promisify doesn't work for s3.upload, it causes s3/managed_upload.js to throw an error `self.service.constructor.__super__ is not a constructor`)
   logger.debug(`Uploading ${pathToZip} to S3 ${Bucket}`);
-  return await new B(async (resolve, reject) => {
+  let body = await fs.readFile(pathToZip);
+  return await new B((resolve, reject) => {
     const uploader = s3.upload({
       Bucket,
       Key: `${uuid()}.zip`, // Name it with a GUID to avoid conflicts
       ACL: 'public-read',
       Expiration: 1, // Expires after one day
-      Body: await fs.readFile(pathToZip),
+      Body: body,
     }, (err, res) => {
       if (err) {
         reject(new Error(`Could not upload ${pathToZip} to S3. Check that you have set the S3 environment variables correctly: ${err}`));
       } else {
         resolve(res);
-        uploader.on('httpUploadProgress', (progress) => logger.debug(`Uploading ${pathToZip} progress ${Math.round(progress.loaded / progress.total * 100)}%`));
       }
+      uploader.on('httpUploadProgress', (progress) => logger.debug(`Uploading ${pathToZip} progress ${Math.round(progress.loaded / progress.total * 100)}%`));
     });
   });
 };

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -1,6 +1,6 @@
 import AWS from 'aws-sdk';
 import B from 'bluebird';
-import { zip, fs } from 'appium-support';
+import { fs } from 'appium-support';
 import { v4 as uuid } from 'uuid';
 import logger from '../lib/logger';
 
@@ -36,8 +36,14 @@ S3.uploadZip = async function (pathToZip) {
       ACL: 'public-read',
       Expiration: 1, // Expires after one day
       Body: await fs.readFile(pathToZip),
-    }, (err, res) => err ? reject(new Error(`Could not upload ${pathToZip} to S3. Check that you have set the S3 environment variables correctly: ${err}`)) : resolve(res));
-    uploader.on('httpUploadProgress', (progress) => logger.debug(`Uploading ${pathToZip} progress ${Math.round(progress.loaded / progress.total * 100 * 100) / 100}%`));
+    }, (err, res) => {
+      if (err) {
+        reject(new Error(`Could not upload ${pathToZip} to S3. Check that you have set the S3 environment variables correctly: ${err}`));
+      } else {
+        resolve(res);
+        uploader.on('httpUploadProgress', (progress) => logger.debug(`Uploading ${pathToZip} progress ${Math.round(progress.loaded / progress.total * 100)}%`));
+      }
+    });
   });
 };
 

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -18,36 +18,26 @@ const S3 = {};
  * Zips a local directory and uploads it to S3
  * @param {*} localDir
  */
-S3.uploadZip = async function (localDir) {
+S3.uploadZip = async function (pathToZip) {
   if (!process.env.AWS_S3_BUCKET) {
     throw new Error('To use S3, you must specify AWS_S3_BUCKET in environment variables');
   }
-  if (!fs.exists(localDir)) {
-    throw new Error(`Could not find directory ${localDir}`);
+  if (!fs.exists(pathToZip)) {
+    throw new Error(`Could not find directory ${pathToZip}`);
   }
-
-  // Attempt to zip the directory
-  let base64Zip;
-  logger.debug(`Zipping ${localDir} to memory`);
-  try {
-    base64Zip = await zip.toInMemoryZip(localDir);
-  } catch (err) {
-    throw new Error(`Could not zip directory ${localDir}: ${err}`);
-  }
-  logger.debug(`Done zipping ${localDir}`);
 
   // Call s3.upload and return it as a promise
   // (NOTE: B.promisify doesn't work for s3.upload, it causes s3/managed_upload.js to throw an error `self.service.constructor.__super__ is not a constructor`)
-  logger.debug(`Uploading ${localDir} to S3 ${Bucket}`);
-  return await new B((resolve, reject) => {
+  logger.debug(`Uploading ${pathToZip} to S3 ${Bucket}`);
+  return await new B(async (resolve, reject) => {
     const uploader = s3.upload({
       Bucket,
-      Key: `${uuid()}.zip`, // Give it a random name
+      Key: `${uuid()}.zip`, // Name it with a GUID to avoid conflicts
       ACL: 'public-read',
       Expiration: 1, // Expires after one day
-      Body: base64Zip,
-    }, (err, res) => err ? reject(new Error(`Could not upload ${localDir} to S3. Check that you have set the S3 environment variables correctly: ${err}`)) : resolve(res));
-    uploader.on('httpUploadProgress', (progress) => logger.debug(`Uploading ${localDir} progress ${Math.round(progress.loaded / progress.total * 100 * 100) / 100}%`));
+      Body: await fs.readFile(pathToZip),
+    }, (err, res) => err ? reject(new Error(`Could not upload ${pathToZip} to S3. Check that you have set the S3 environment variables correctly: ${err}`)) : resolve(res));
+    uploader.on('httpUploadProgress', (progress) => logger.debug(`Uploading ${pathToZip} progress ${Math.round(progress.loaded / progress.total * 100 * 100) / 100}%`));
   });
 };
 

--- a/lib/testobject.js
+++ b/lib/testobject.js
@@ -16,11 +16,13 @@ TestObject.DEFAULT_IOS_DEVICE = 'iPad_2_16GB_real';
 TestObject.getTestObjectCaps = async function (caps = {}) {
   // Upload the app to TestObject
   let testobjectAppId;
+  logger.debug(`Uploading TestObject app: ${caps.app}`);
   try {
     testobjectAppId = await TestObject.uploadTestObjectApp(caps.app);
   } catch (e) {
     throw new Error(`Could not upload ${caps.app} to TestObject: ${e.message}`);
   }
+  logger.debug(`Done uploading TestObject app: ${caps.app}. AppID is ${testobjectAppId}`);
 
   // Determine the TestObject_device
   let testobjectDevice;
@@ -140,8 +142,8 @@ TestObject.restoreWD = function (wd, originalPromiseChainRemote) {
 /**
  * Uploads zip to S3 and overrides WD to use TO objects
  */
-TestObject.enableTestObject = async function (wd, driverName, driverUrl, driverBranch) {
-  const appiumZip = await TestObject.fetchAppium(driverName, driverUrl, driverBranch);
+TestObject.enableTestObject = async function (wd, driverName, driverUrl) {
+  const appiumZip = await TestObject.fetchAppium(driverName, driverUrl);
   logger.debug(`Uploading '${appiumZip}' to S3`);
   let appiumS3Object;
   try {
@@ -170,25 +172,25 @@ TestObject.disableTestObject = async function ({wdOverride, appiumS3Object, wd})
   await S3.deleteZip(appiumS3Object.Key);
 };
 
-TestObject.fetchAppium = async function (driverName, driverUrl, driverBranch='master') {
+TestObject.fetchAppium = async function (driverName, driverUrl) {
   // Clone appium
   const tempdir = await tempDir.openDir();
   const pathToAppium = path.resolve(tempdir, 'appium');
   await fs.rimraf(pathToAppium);
   logger.debug('Cloning appium');
-  await exec('git', ['clone', '-b', driverBranch, 'git@github.com:appium/appium.git'], {cwd: tempdir});
+  await exec('git', ['clone', 'git@github.com:appium/appium.git'], {cwd: tempdir});
   logger.debug(`Cloned appium at ${tempdir}`);
 
   // Rewrite the package.json to use the branch
   logger.debug(`Rewriting ${driverName} in package.json to ${driverUrl}`);
-  const packageJSON = JSON.parse(await fs.readFile(path.resolve(pathToAppium, 'package.json'), 'utf8'));
+  const packageJSON = JSON.parse(require(path.resolve(pathToAppium, 'package.json')));
   packageJSON.dependencies[driverName] = driverUrl;
   await fs.writeFile(path.resolve(pathToAppium, 'package.json'), JSON.stringify(packageJSON));
 
   // Install node modules
-  logger.debug(`Installing node modules`);
+  logger.debug(`Running 'npm install' at ${pathToAppium}`);
   await exec('npm', ['install'], {cwd: pathToAppium});
-  logger.debug(`Done installing node modules`);
+  logger.debug(`Done running 'npm install'`);
 
   // Zip it and return it
   const pathToZip = path.resolve(tempdir, 'appium.zip');

--- a/lib/testobject.js
+++ b/lib/testobject.js
@@ -20,7 +20,7 @@ TestObject.getTestObjectCaps = async function (caps = {}) {
   try {
     testobjectAppId = await TestObject.uploadTestObjectApp(caps.app);
   } catch (e) {
-    throw new Error(`Could not upload ${caps.app} to TestObject: ${e.message}`);
+    throw new Error(`Could not upload '${caps.app}' to TestObject: ${e.message}`);
   }
   logger.debug(`Done uploading TestObject app: ${caps.app}. AppID is ${testobjectAppId}`);
 
@@ -88,7 +88,7 @@ TestObject.uploadTestObjectApp = async function (app) {
     };
     return appId;
   } catch (e) {
-    logger.error(`Could not upload ${app} to TestObject. Log into https://app.staging.testobject.org/ and verify that ${app} has been uploaded manually.
+    logger.error(`Could not upload '${app}' to TestObject. Log into https://app.staging.testobject.org/ and verify that ${app} has been uploaded manually.
       The API call to /api/storage/upload re-uploads apps. It doesn't upload them the first time: (${e})`);
     throw e;
   }
@@ -149,10 +149,10 @@ TestObject.enableTestObject = async function (wd, driverName, driverUrl) {
   try {
     appiumS3Object = await S3.uploadZip(appiumZip);
   } catch (e) {
-    logger.error(`Could not upload ${appiumZip} to S3. Reason: (${e.message})`);
+    logger.error(`Could not upload '${appiumZip}' to S3. Reason: (${e.message})`);
     throw e;
   }
-  logger.debug(`Uploading of '${appiumZip} complete`);
+  logger.debug(`Uploading of '${appiumZip}' complete`);
   await fs.rimraf(appiumZip);
 
   // Overriding WD so it uses the appiumS3Object.Location
@@ -183,7 +183,7 @@ TestObject.fetchAppium = async function (driverName, driverUrl) {
 
   // Rewrite the package.json to use the branch
   logger.debug(`Rewriting ${driverName} in package.json to ${driverUrl}`);
-  const packageJSON = JSON.parse(require(path.resolve(pathToAppium, 'package.json')));
+  const packageJSON = require(path.resolve(pathToAppium, 'package.json'));
   packageJSON.dependencies[driverName] = driverUrl;
   await fs.writeFile(path.resolve(pathToAppium, 'package.json'), JSON.stringify(packageJSON));
 

--- a/lib/testobject.js
+++ b/lib/testobject.js
@@ -1,13 +1,10 @@
-import Github from 'github';
 import path from 'path';
 import S3 from './s3';
 import { exec } from 'teen_process';
-import { fs, tempDir, mkdirp } from 'appium-support';
+import { fs, tempDir } from 'appium-support';
 import logger from '../lib/logger';
 import _ from 'lodash';
 import B from 'bluebird';
-import nodeFS from 'fs';
-import request from 'request-promise';
 
 const TestObject = {};
 
@@ -197,7 +194,7 @@ TestObject.fetchAppium = async function (driverName, driverUrl) {
   // Zip it and return it
   const pathToZip = path.resolve(tempdir, 'appium.zip');
   logger.debug(`Writing zip file to ${pathToZip}`);
-  await exec('zip', ['-r', 'appium.zip', 'appium/'], {cwd: tempdir})
+  await exec('zip', ['-r', 'appium.zip', 'appium/'], {cwd: tempdir});
   await fs.rimraf(path.resolve(tempdir, 'appium'));
   return pathToZip;
 };

--- a/lib/testobject.js
+++ b/lib/testobject.js
@@ -140,8 +140,8 @@ TestObject.restoreWD = function (wd, originalPromiseChainRemote) {
 /**
  * Uploads zip to S3 and overrides WD to use TO objects
  */
-TestObject.enableTestObject = async function (wd, driverName, driverUrl) {
-  const appiumZip = await TestObject.fetchAppium(driverName, driverUrl);
+TestObject.enableTestObject = async function (wd, driverName, driverUrl, driverBranch) {
+  const appiumZip = await TestObject.fetchAppium(driverName, driverUrl, driverBranch);
   logger.debug(`Uploading '${appiumZip}' to S3`);
   let appiumS3Object;
   try {

--- a/lib/testobject.js
+++ b/lib/testobject.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import S3 from './s3';
 import { exec } from 'teen_process';
 import { fs } from 'appium-support';
@@ -135,6 +136,11 @@ TestObject.restoreWD = function (wd, originalPromiseChainRemote) {
   wd.promiseChainRemote = originalPromiseChainRemote;
 };
 
+TestObject.injectDriverIntoAppium = async function (srcAppium, destAppium, pathToAppiumDriver, appiumDriverName) {
+  await fs.copyFile(srcAppium, destAppium);
+  await fs.rimraf(path.resolve(destAppium, 'node_modules', appiumDriverName));
+  await fs.copyFile(pathToAppiumDriver, path.resolve(destAppium, 'node_modules', appiumDriverName));
+};
 
 /**
  * Uploads zip to S3 and overrides WD to use TO objects

--- a/lib/testobject.js
+++ b/lib/testobject.js
@@ -4,7 +4,6 @@ import { exec } from 'teen_process';
 import { fs, tempDir } from 'appium-support';
 import logger from '../lib/logger';
 import _ from 'lodash';
-import B from 'bluebird';
 
 const TestObject = {};
 

--- a/lib/testobject.js
+++ b/lib/testobject.js
@@ -1,13 +1,17 @@
+import Github from 'github';
 import path from 'path';
 import S3 from './s3';
 import { exec } from 'teen_process';
-import { fs } from 'appium-support';
+import { fs, tempDir, mkdirp } from 'appium-support';
 import logger from '../lib/logger';
 import _ from 'lodash';
+import B from 'bluebird';
+import nodeFS from 'fs';
+import request from 'request-promise';
 
 const TestObject = {};
 
-TestObject.DEFAULT_DEVICE = 'Samsung_I9505_Galaxy_S4_real';
+TestObject.DEFAULT_DEVICE = 'HTC_One_M8_real';
 TestObject.DEFAULT_IOS_DEVICE = 'iPad_2_16GB_real';
 
 /**
@@ -94,7 +98,7 @@ TestObject.uploadTestObjectApp = async function (app) {
 
 TestObject.MOCHA_TESTOBJECT_TIMEOUT = 30 * 60 * 1000; // Half an hour limit
 
-TestObject.HOST = 'app.staging.testobject.org';
+TestObject.HOST = 'appium.staging.testobject.org';
 TestObject.PORT = 443;
 
 /**
@@ -121,6 +125,7 @@ TestObject.overrideWD = function (wd, appiumZipUrl) {
       const extendedCaps = await TestObject.getTestObjectCaps(caps);
       logger.debug(`Setting caps.testobject_remote_appium_url to ${appiumZipUrl}`);
       extendedCaps.testobject_remote_appium_url = appiumZipUrl;
+      logger.debug(`Waiting to connect to TestObject staging server (this can take several minutes)`);
       return await originalInit.call(driver, extendedCaps, ...args);
     };
     return driver;
@@ -136,25 +141,21 @@ TestObject.restoreWD = function (wd, originalPromiseChainRemote) {
   wd.promiseChainRemote = originalPromiseChainRemote;
 };
 
-TestObject.injectDriverIntoAppium = async function (srcAppium, destAppium, pathToAppiumDriver, appiumDriverName) {
-  await fs.copyFile(srcAppium, destAppium);
-  await fs.rimraf(path.resolve(destAppium, 'node_modules', appiumDriverName));
-  await fs.copyFile(pathToAppiumDriver, path.resolve(destAppium, 'node_modules', appiumDriverName));
-};
-
 /**
  * Uploads zip to S3 and overrides WD to use TO objects
  */
-TestObject.enableTestObject = async function (wd, appiumDir) {
-  appiumDir = appiumDir || process.env.PWD; // Default to PWD if no appium directory provided
-  logger.debug(`Uploading '${appiumDir}' to S3`);
+TestObject.enableTestObject = async function (wd, driverName, driverUrl) {
+  const appiumZip = await TestObject.fetchAppium(driverName, driverUrl);
+  logger.debug(`Uploading '${appiumZip}' to S3`);
   let appiumS3Object;
   try {
-    appiumS3Object = await S3.uploadZip(appiumDir);
+    appiumS3Object = await S3.uploadZip(appiumZip);
   } catch (e) {
-    logger.error(`Could not upload ${appiumDir} to S3. Reason: (${e.message})`);
+    logger.error(`Could not upload ${appiumZip} to S3. Reason: (${e.message})`);
     throw e;
   }
+  logger.debug(`Uploading of '${appiumZip} complete`);
+  await fs.rimraf(appiumZip);
 
   // Overriding WD so it uses the appiumS3Object.Location
   return {
@@ -171,6 +172,34 @@ TestObject.enableTestObject = async function (wd, appiumDir) {
 TestObject.disableTestObject = async function ({wdOverride, appiumS3Object, wd}) {
   TestObject.restoreWD(wd, wdOverride);
   await S3.deleteZip(appiumS3Object.Key);
+};
+
+TestObject.fetchAppium = async function (driverName, driverUrl) {
+  // Clone appium
+  const tempdir = await tempDir.openDir();
+  const pathToAppium = path.resolve(tempdir, 'appium');
+  await fs.rimraf(pathToAppium);
+  logger.debug('Cloning appium');
+  await exec('git', ['clone', 'git@github.com:appium/appium.git'], {cwd: tempdir});
+  logger.debug(`Cloned appium at ${tempdir}`);
+
+  // Rewrite the package.json to use the branch
+  logger.debug(`Rewriting ${driverName} in package.json to ${driverUrl}`);
+  const packageJSON = JSON.parse(await fs.readFile(path.resolve(pathToAppium, 'package.json'), 'utf8'));
+  packageJSON.dependencies[driverName] = driverUrl;
+  await fs.writeFile(path.resolve(pathToAppium, 'package.json'), JSON.stringify(packageJSON));
+
+  // Install node modules
+  logger.debug(`Installing node modules`);
+  await exec('npm', ['install'], {cwd: pathToAppium});
+  logger.debug(`Done installing node modules`);
+
+  // Zip it and return it
+  const pathToZip = path.resolve(tempdir, 'appium.zip');
+  logger.debug(`Writing zip file to ${pathToZip}`);
+  await exec('zip', ['-r', 'appium.zip', 'appium/'], {cwd: tempdir})
+  await fs.rimraf(path.resolve(tempdir, 'appium'));
+  return pathToZip;
 };
 
 export default TestObject;

--- a/lib/testobject.js
+++ b/lib/testobject.js
@@ -171,13 +171,13 @@ TestObject.disableTestObject = async function ({wdOverride, appiumS3Object, wd})
   await S3.deleteZip(appiumS3Object.Key);
 };
 
-TestObject.fetchAppium = async function (driverName, driverUrl) {
+TestObject.fetchAppium = async function (driverName, driverUrl, driverBranch='master') {
   // Clone appium
   const tempdir = await tempDir.openDir();
   const pathToAppium = path.resolve(tempdir, 'appium');
   await fs.rimraf(pathToAppium);
   logger.debug('Cloning appium');
-  await exec('git', ['clone', 'git@github.com:appium/appium.git'], {cwd: tempdir});
+  await exec('git', ['clone', '-b', driverBranch, 'git@github.com:appium/appium.git'], {cwd: tempdir});
   logger.debug(`Cloned appium at ${tempdir}`);
 
   // Rewrite the package.json to use the branch

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-mocha": "^4.7.0",
     "eslint-plugin-promise": "^3.3.1",
-    "github": "^10.1.0",
     "gulp": "^3.8.11",
     "mocha": "^3.5.0",
     "pre-commit": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -63,14 +63,12 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-mocha": "^4.7.0",
     "eslint-plugin-promise": "^3.3.1",
+    "github": "^10.1.0",
     "gulp": "^3.8.11",
-<<<<<<< HEAD
     "mocha": "^3.5.0",
     "pre-commit": "^1.2.2",
-=======
-    "mock-fs": "^4.4.1",
->>>>>>> Added method that injects driver into appium
     "request-promise": "^4.2.0",
-    "wd": "^1.2.0"
+    "wd": "^1.2.0",
+    "mock-fs": "^4.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,8 +64,12 @@
     "eslint-plugin-mocha": "^4.7.0",
     "eslint-plugin-promise": "^3.3.1",
     "gulp": "^3.8.11",
+<<<<<<< HEAD
     "mocha": "^3.5.0",
     "pre-commit": "^1.2.2",
+=======
+    "mock-fs": "^4.4.1",
+>>>>>>> Added method that injects driver into appium
     "request-promise": "^4.2.0",
     "wd": "^1.2.0"
   }

--- a/test/e2e/s3-e2e-specs.js
+++ b/test/e2e/s3-e2e-specs.js
@@ -13,7 +13,7 @@ chai.should();
 chai.use(chaiAsPromised);
 
 describe('S3', () => {
-  let tempDir, testDir;
+  let tempDir, testDir, zipPath;
 
   before(async () => {
     // Create a temporary directory with one file and upload it to S3
@@ -21,7 +21,8 @@ describe('S3', () => {
     testDir = path.resolve(tempDir, 'test-dir');
     await mkdir(testDir);
     const fileContents = 'Temporary file contents';
-    await writeFile(path.resolve(testDir, 'temp-file.txt'), fileContents);
+    zipPath = path.resolve(testDir, 'temp-file.zip');
+    await writeFile(zipPath, fileContents);
   });
 
   it('should zip directories and publish them to S3 and then unpublish them', async function () {
@@ -29,7 +30,7 @@ describe('S3', () => {
     if (!process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_ACCESS_KEY) {
       this.skip();
     }
-    const res = await uploadZip(testDir);
+    const res = await uploadZip(zipPath);
 
     // Download the zipped directory, unzip it, and compare it's contents to the original temporary directory
     await request(res.Location).should.eventually.be.resolved;

--- a/test/e2e/testobject-e2e-specs.js
+++ b/test/e2e/testobject-e2e-specs.js
@@ -3,13 +3,20 @@ import chaiAsPromised from 'chai-as-promised';
 import path from 'path';
 import wd from 'wd';
 import request from 'request-promise';
-import { uploadTestObjectApp, disableTestObject, enableTestObject } from '../../lib/testobject';
+import { fs } from 'appium-support';
+import { uploadTestObjectApp, disableTestObject, enableTestObject, fetchAppium } from '../../lib/testobject';
 
 chai.should();
 chai.use(chaiAsPromised);
 
 describe('TestObject', function () {
-  this.timeout(20 * 60 * 1000);
+  describe('#fetchAppium', function () {
+    it('fetches appium zip', async function () {
+      const appiumZip = await fetchAppium('appium-uiautomator2-driver', 'git+ssh://git@github.com/appium/appium-uiautomator2-driver.git');
+      await fs.exists(appiumZip).should.eventually.be.true;
+    });
+  });
+
   describe('#uploadTestObjectApp', function () {
     it('should upload fake app file to testObject', async function () {
       await uploadTestObjectApp(path.resolve('test', 'fixtures', 'ContactManager.apk')).should.eventually.be.resolved;
@@ -18,7 +25,7 @@ describe('TestObject', function () {
 
   describe('.enableTestObject, .disableTestObject', function () {
     it('should enable testObject tests and then be able to disable them afterwards', async function () {
-      const wdObject = await enableTestObject(wd, path.resolve(process.env.PWD, 'node_modules', 'appium'));
+      const wdObject = await enableTestObject(wd, 'appium-uiautomator2-driver', 'git+ssh://git@github.com/appium/appium-uiautomator2-driver.git');
 
       // Test that the zip was uploaded
       const location = wdObject.appiumS3Object.Location;

--- a/test/e2e/testobject-e2e-specs.js
+++ b/test/e2e/testobject-e2e-specs.js
@@ -13,7 +13,7 @@ describe('TestObject', function () {
   describe('#fetchAppium', function () {
     it('fetches appium zip', async function () {
       const appiumZip = await fetchAppium(
-        'appium-uiautomator2-driver', 
+        'appium-uiautomator2-driver',
         'git+ssh://git@github.com/appium/appium-uiautomator2-driver.git',
         'master'
       );

--- a/test/e2e/testobject-e2e-specs.js
+++ b/test/e2e/testobject-e2e-specs.js
@@ -12,7 +12,11 @@ chai.use(chaiAsPromised);
 describe('TestObject', function () {
   describe('#fetchAppium', function () {
     it('fetches appium zip', async function () {
-      const appiumZip = await fetchAppium('appium-uiautomator2-driver', 'git+ssh://git@github.com/appium/appium-uiautomator2-driver.git');
+      const appiumZip = await fetchAppium(
+        'appium-uiautomator2-driver', 
+        'git+ssh://git@github.com/appium/appium-uiautomator2-driver.git',
+        'master'
+      );
       await fs.exists(appiumZip).should.eventually.be.true;
     });
   });

--- a/test/s3-specs.js
+++ b/test/s3-specs.js
@@ -7,7 +7,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import AWS from 'aws-sdk';
-import { zip, fs } from 'appium-support';
+import { fs } from 'appium-support';
 chai.should();
 chai.use(chaiAsPromised);
 

--- a/test/s3-specs.js
+++ b/test/s3-specs.js
@@ -15,14 +15,14 @@ describe('s3', () => {
   let s3Proto = Object.getPrototypeOf(new AWS.S3());
 
   describe('uploadZip', () => {
-    let zipStub, fileExistsStub;
+    let fileExistsStub, readFileStub;
     beforeEach(() => {
-      zipStub = sinon.stub(zip, 'toInMemoryZip', () => 'ABC');
       fileExistsStub = sinon.stub(fs, 'exists', () => true);
+      readFileStub = sinon.stub(fs, 'readFile', () => "dummy");
     });
     afterEach(() => {
       fileExistsStub.restore();
-      zipStub.restore();
+      readFileStub.restore();
     });
     it('should reject if AWS_S3_BUCKET not defined in env', async () => {
       const backupBucket = process.env.AWS_S3_BUCKET;
@@ -33,16 +33,11 @@ describe('s3', () => {
     it('should reject if file does not exist', async () => {
       fileExistsStub.restore();
       fileExistsStub = sinon.stub(fs, 'exists', () => false);
-      await uploadZip().should.eventually.be.rejectedWith(/Could not find/);
-    });
-    it('should reject if zip fails', async () => {
-      zipStub.restore();
-      zipStub = sinon.stub(zip, 'toInMemoryZip', () => { throw new Error('Zip failed'); });
-      await uploadZip().should.eventually.be.rejectedWith(/Could not zip/);
+      await uploadZip('/fake/file/path.zip').should.eventually.be.rejectedWith(/Could not find/);
     });
     it('should reject if s3.upload fails', async () => {
       const uploaderStub = sinon.stub(s3Proto, 'upload', (obj, cb) => { cb(new Error('does not matter')); });
-      await uploadZip().should.eventually.be.rejectedWith(/Could not upload/);
+      await uploadZip('/fake/file/path.zip').should.eventually.be.rejectedWith(/Could not upload/);
       uploaderStub.restore();
     });
     it('should pass if s3.upload does not fail', async () => {

--- a/test/testobject-specs.js
+++ b/test/testobject-specs.js
@@ -2,8 +2,7 @@
 
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import path from 'path';
-import { stubEnv } from '../..';
+import { stubEnv } from '..';
 import sinon from 'sinon';
 import TestObject from '../lib/testobject';
 import S3 from '../lib/s3';

--- a/test/testobject-specs.js
+++ b/test/testobject-specs.js
@@ -176,24 +176,30 @@ describe('testobject-utils.js', function () {
   });
 
   describe('#enableTestObject', function () {
-    let uploadZipStub, overrideWDStub;
+    let uploadZipStub, overrideWDStub, fetchAppiumStub, rimrafStub;
 
     beforeEach(async function () {
       uploadZipStub = sinon.stub(S3, 'uploadZip');
       overrideWDStub = sinon.stub(TestObject, 'overrideWD');
+      fetchAppiumStub = sinon.stub(TestObject, 'fetchAppium');
+      rimrafStub = sinon.stub(fs, 'rimraf');
     });
 
     afterEach(function () {
       uploadZipStub.restore();
       overrideWDStub.restore();
+      fetchAppiumStub.restore();
+      rimrafStub.restore();
     });
 
     it('should be rejected if it fails to upload appiumDir zip', async function () {
       uploadZipStub.throws('S3 Upload Error');
+      fetchAppiumStub.returns('/fake/path/to/zip.zip');
       await TestObject.enableTestObject(null, '/does/not/matter').should.eventually.be.rejectedWith(/S3 Upload Error/);
     });
 
     it('should call uploadZip and then return the result of overrideWD', async function () {
+      rimrafStub.returns(true);
       let fakeWD = {fakeWD: 'fakeWD'};
       uploadZipStub.reset();
       uploadZipStub.returns({Location: 'HelloWorldLand', Key: 'key'});

--- a/test/testobject-specs.js
+++ b/test/testobject-specs.js
@@ -2,12 +2,18 @@
 
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+<<<<<<< HEAD
 import { stubEnv } from '..';
+=======
+import mockFS from 'mock-fs';
+import path from 'path';
+import { stubEnv } from '../..';
+>>>>>>> Added method that injects driver into appium
 import sinon from 'sinon';
 import TestObject from '../lib/testobject';
 import S3 from '../lib/s3';
 import * as teenProcess from 'teen_process';
-const { getTestObjectCaps, uploadTestObjectApp, overrideWD } = TestObject;
+const { getTestObjectCaps, uploadTestObjectApp, overrideWD, injectDriverIntoAppium } = TestObject;
 import { fs } from 'appium-support';
 
 chai.should();
@@ -227,4 +233,69 @@ describe('testobject-utils.js', function () {
       TestObject.disableTestObject(wdObj).should.eventually.be.resolved;
     });
   });
+<<<<<<< HEAD
 });
+=======
+  describe('#injectDriverIntoAppium', function () {
+    const fakePath = 'fake/dir/path/';
+  
+    beforeEach(async function () {
+      mockFS({
+        [fakePath]: {
+          'appium': {
+            'node_modules': {
+              'appium-hello-driver': {
+                'a.txt': 'A',
+                'b.txt': 'B',
+              },
+              'appium-world-driver': {
+                'c.txt': 'C',
+                'd.txt': 'D',
+              },
+            }
+          },
+          'appium-world-driver': {
+            'e.txt': 'E',
+            'f.txt': 'F',
+          },
+          'appium-new-driver': {
+            'g.txt': 'G',
+            'h.txt': 'H',
+          },
+        },
+      });
+    });
+    after(function () {
+      mockFS.restore();
+    });
+    it('should add driver to node_modules if the driver is new', async function () {
+      await fs.readFile(path.resolve(fakePath, 'appium', 'appium-new-driver', 'g.txt')).should.eventually.be.rejectedWith(/ENOENT/);
+      await fs.exists(path.resolve(fakePath, 'appium-dest')).should.eventually.be.false;
+      await injectDriverIntoAppium(
+        path.resolve(fakePath, 'appium'), 
+        path.resolve(fakePath, 'appium-dest'), 
+        path.resolve(fakePath, 'appium-new-driver'), 
+        'appium-new-driver'
+      );
+      await fs.exists(path.resolve(fakePath, 'appium-dest')).should.eventually.be.true;
+      await fs.exists(path.resolve(fakePath, 'appium-dest', 'node_modules', 'appium-new-driver')).should.eventually.be.true;
+      await fs.readFile(path.resolve(fakePath, 'appium-dest', 'node_modules', 'appium-new-driver', 'g.txt'), 'utf8').should.eventually.equal('G');
+      await fs.readFile(path.resolve(fakePath, 'appium-dest', 'node_modules', 'appium-new-driver', 'h.txt'), 'utf8').should.eventually.equal('H');
+    });
+    it('should delete what is currently the driver and replace it with a new one', async function () {
+      await fs.readFile(path.resolve(fakePath, 'appium', 'node_modules', 'appium-world-driver', 'c.txt'), 'utf8').should.eventually.equal('C');
+      await fs.readFile(path.resolve(fakePath, 'appium', 'node_modules', 'appium-world-driver', 'd.txt'), 'utf8').should.eventually.equal('D');
+      await injectDriverIntoAppium(
+        path.resolve(fakePath, 'appium'), 
+        path.resolve(fakePath, 'appium-dest'),
+        path.resolve(fakePath, 'appium-world-driver'), 
+        'appium-world-driver'
+      );
+      await fs.readFile(path.resolve(fakePath, 'appium-dest', 'node_modules', 'appium-world-driver', 'e.txt'), 'utf8').should.eventually.equal('E');
+      await fs.readFile(path.resolve(fakePath, 'appium-dest', 'node_modules', 'appium-world-driver', 'f.txt'), 'utf8').should.eventually.equal('F');
+      await fs.readFile(path.resolve(fakePath, 'appium', 'node_modules', 'appium-world-driver', 'c.txt'), 'utf8').should.eventually.equal('C');
+      await fs.readFile(path.resolve(fakePath, 'appium', 'node_modules', 'appium-world-driver', 'd.txt'), 'utf8').should.eventually.equal('D');
+    });
+  });
+});
+>>>>>>> Added method that injects driver into appium

--- a/test/testobject-specs.js
+++ b/test/testobject-specs.js
@@ -2,18 +2,13 @@
 
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-<<<<<<< HEAD
-import { stubEnv } from '..';
-=======
-import mockFS from 'mock-fs';
 import path from 'path';
 import { stubEnv } from '../..';
->>>>>>> Added method that injects driver into appium
 import sinon from 'sinon';
 import TestObject from '../lib/testobject';
 import S3 from '../lib/s3';
 import * as teenProcess from 'teen_process';
-const { getTestObjectCaps, uploadTestObjectApp, overrideWD, injectDriverIntoAppium } = TestObject;
+const { getTestObjectCaps, uploadTestObjectApp, overrideWD } = TestObject;
 import { fs } from 'appium-support';
 
 chai.should();
@@ -233,69 +228,4 @@ describe('testobject-utils.js', function () {
       TestObject.disableTestObject(wdObj).should.eventually.be.resolved;
     });
   });
-<<<<<<< HEAD
 });
-=======
-  describe('#injectDriverIntoAppium', function () {
-    const fakePath = 'fake/dir/path/';
-  
-    beforeEach(async function () {
-      mockFS({
-        [fakePath]: {
-          'appium': {
-            'node_modules': {
-              'appium-hello-driver': {
-                'a.txt': 'A',
-                'b.txt': 'B',
-              },
-              'appium-world-driver': {
-                'c.txt': 'C',
-                'd.txt': 'D',
-              },
-            }
-          },
-          'appium-world-driver': {
-            'e.txt': 'E',
-            'f.txt': 'F',
-          },
-          'appium-new-driver': {
-            'g.txt': 'G',
-            'h.txt': 'H',
-          },
-        },
-      });
-    });
-    after(function () {
-      mockFS.restore();
-    });
-    it('should add driver to node_modules if the driver is new', async function () {
-      await fs.readFile(path.resolve(fakePath, 'appium', 'appium-new-driver', 'g.txt')).should.eventually.be.rejectedWith(/ENOENT/);
-      await fs.exists(path.resolve(fakePath, 'appium-dest')).should.eventually.be.false;
-      await injectDriverIntoAppium(
-        path.resolve(fakePath, 'appium'), 
-        path.resolve(fakePath, 'appium-dest'), 
-        path.resolve(fakePath, 'appium-new-driver'), 
-        'appium-new-driver'
-      );
-      await fs.exists(path.resolve(fakePath, 'appium-dest')).should.eventually.be.true;
-      await fs.exists(path.resolve(fakePath, 'appium-dest', 'node_modules', 'appium-new-driver')).should.eventually.be.true;
-      await fs.readFile(path.resolve(fakePath, 'appium-dest', 'node_modules', 'appium-new-driver', 'g.txt'), 'utf8').should.eventually.equal('G');
-      await fs.readFile(path.resolve(fakePath, 'appium-dest', 'node_modules', 'appium-new-driver', 'h.txt'), 'utf8').should.eventually.equal('H');
-    });
-    it('should delete what is currently the driver and replace it with a new one', async function () {
-      await fs.readFile(path.resolve(fakePath, 'appium', 'node_modules', 'appium-world-driver', 'c.txt'), 'utf8').should.eventually.equal('C');
-      await fs.readFile(path.resolve(fakePath, 'appium', 'node_modules', 'appium-world-driver', 'd.txt'), 'utf8').should.eventually.equal('D');
-      await injectDriverIntoAppium(
-        path.resolve(fakePath, 'appium'), 
-        path.resolve(fakePath, 'appium-dest'),
-        path.resolve(fakePath, 'appium-world-driver'), 
-        'appium-world-driver'
-      );
-      await fs.readFile(path.resolve(fakePath, 'appium-dest', 'node_modules', 'appium-world-driver', 'e.txt'), 'utf8').should.eventually.equal('E');
-      await fs.readFile(path.resolve(fakePath, 'appium-dest', 'node_modules', 'appium-world-driver', 'f.txt'), 'utf8').should.eventually.equal('F');
-      await fs.readFile(path.resolve(fakePath, 'appium', 'node_modules', 'appium-world-driver', 'c.txt'), 'utf8').should.eventually.equal('C');
-      await fs.readFile(path.resolve(fakePath, 'appium', 'node_modules', 'appium-world-driver', 'd.txt'), 'utf8').should.eventually.equal('D');
-    });
-  });
-});
->>>>>>> Added method that injects driver into appium


### PR DESCRIPTION
* Added a `fetchAppium` method that
  * Clones Appium into a temporary directory
  * Parses the package.json and points a driver to a GitHub url instead of a version number
  * Installs the node modules
  * Zips the appium directory
* The `enableTestObject` method calls `fetchAppium`, sends the zip to S3 and then uses the link to the zip as the `testobject_remote_appium_url`