### PR TITLE
Re-use zips that are uploaded to S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
+sudo: required
 language: node_js
 node_js:
   - "6"
   - "7"
 after_success:
   - npm run coverage
+script:
+  - npm run build
+  - npm test
+  - npm run e2e-test

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -1,7 +1,6 @@
 import AWS from 'aws-sdk';
 import B from 'bluebird';
 import { fs } from 'appium-support';
-import { v4 as uuid } from 'uuid';
 import logger from '../lib/logger';
 
 const Bucket = process.env.AWS_S3_BUCKET;
@@ -18,12 +17,17 @@ const S3 = {};
  * Zips a local directory and uploads it to S3
  * @param {*} localDir
  */
-S3.uploadZip = async function (pathToZip) {
+S3.uploadZip = async function (pathToZip, zipfileName) {
   if (!process.env.AWS_S3_BUCKET) {
     throw new Error('To use S3, you must specify AWS_S3_BUCKET in environment variables');
   }
   if (!fs.exists(pathToZip)) {
     throw new Error(`Could not find directory ${pathToZip}`);
+  }
+
+  // If this file already exists, don't create a new one
+  if (await S3.fileExists(zipfileName)) {
+    return S3.getS3Location(zipfileName);
   }
 
   // Call s3.upload and return it as a promise
@@ -33,7 +37,7 @@ S3.uploadZip = async function (pathToZip) {
   return await new B((resolve, reject) => {
     const uploader = s3.upload({
       Bucket,
-      Key: `${uuid()}.zip`, // Name it with a GUID to avoid conflicts
+      Key: zipfileName, // Name it with a GUID to avoid conflicts
       ACL: 'public-read',
       Expiration: 1, // Expires after one day
       Body: body,
@@ -41,26 +45,34 @@ S3.uploadZip = async function (pathToZip) {
       if (err) {
         reject(new Error(`Could not upload ${pathToZip} to S3. Check that you have set the S3 environment variables correctly: ${err}`));
       } else {
-        resolve(res);
+        logger.debug(`File uploaded as ${res.Location}`);
+        resolve(res.Location);
       }
     });
     uploader.on('httpUploadProgress', (progress) => logger.debug(`Uploading ${pathToZip} progress ${Math.round(progress.loaded / progress.total * 100)}%`));
   });
 };
 
-/**
- * Deletes a file at given URL
- */
-S3.deleteZip = async function (key) {
-  if (!process.env.AWS_S3_BUCKET) {
-    throw new Error('To use S3, you must specify AWS_S3_BUCKET in environment variables');
-  }
-  return await new B((resolve, reject) => {
-    s3.deleteObject({
-      Bucket: process.env.AWS_S3_BUCKET,
-      Key: key,
-    }, (err, res) => err ? reject(new Error(`Could not delete zip ${key}: ${err}`)) : resolve(res));
+S3.fileExists = async function (fileName) {
+  logger.debug(`Looking for cached copy of ${fileName}`);
+  return await new B((resolve) => {
+    s3.headObject({
+      Bucket,
+      Key: fileName,
+    }, (err) => {
+      if (err) {
+        logger.debug(`Copy of ${fileName} not found.`);
+        resolve(false);
+      } else {
+        logger.debug(`Found a copy of ${fileName}`);
+        resolve(true);
+      }
+    });
   });
+};
+
+S3.getS3Location = function (fileName) {
+  return `https://${process.env.AWS_S3_BUCKET}.s3.${process.env.AWS_REGION}.amazonaws.com/${encodeURIComponent(fileName)}`;
 };
 
 export default S3;

--- a/lib/testobject.js
+++ b/lib/testobject.js
@@ -1,7 +1,8 @@
 import path from 'path';
 import S3 from './s3';
-import { exec } from 'teen_process';
+import { exec, SubProcess } from 'teen_process';
 import { fs, tempDir } from 'appium-support';
+import B from 'bluebird';
 import logger from '../lib/logger';
 import _ from 'lodash';
 
@@ -133,32 +134,32 @@ TestObject.overrideWD = function (wd, appiumZipUrl) {
 };
 
 /**
- * Undo the overrides done in WD
- */
-TestObject.restoreWD = function (wd, originalPromiseChainRemote) {
-  wd.promiseChainRemote = originalPromiseChainRemote;
-};
-
-/**
  * Uploads zip to S3 and overrides WD to use TO objects
  */
 TestObject.enableTestObject = async function (wd, driverName, driverUrl) {
-  const appiumZip = await TestObject.fetchAppium(driverName, driverUrl);
-  logger.debug(`Uploading '${appiumZip}' to S3`);
-  let appiumS3Object;
-  try {
-    appiumS3Object = await S3.uploadZip(appiumZip);
-  } catch (e) {
-    logger.error(`Could not upload '${appiumZip}' to S3. Reason: (${e.message})`);
-    throw e;
+  const zipfileName = `${driverName}_${driverUrl}`;
+  let s3Location;
+  if (await S3.fileExists(zipfileName)) {
+    logger.debug(`Reusing cached version of '${zipfileName}'`);
+    s3Location = S3.getS3Location(zipfileName);
+  } else {
+    const appiumZip = await TestObject.fetchAppium(driverName, driverUrl);
+    logger.debug(`Uploading '${appiumZip}' to S3`);
+    try {
+      s3Location = await S3.uploadZip(appiumZip, zipfileName);
+    } catch (e) {
+      logger.error(`Could not upload '${appiumZip}' to S3. Reason: (${e.message})`);
+      throw e;
+    }
+    logger.debug(`Uploading of '${appiumZip}' complete`);
+    logger.debug(`Zip was uploaded to ${s3Location}`);
+    await fs.rimraf(appiumZip);
   }
-  logger.debug(`Uploading of '${appiumZip}' complete`);
-  await fs.rimraf(appiumZip);
 
   // Overriding WD so it uses the appiumS3Object.Location
   return {
-    wdOverride: TestObject.overrideWD(wd, appiumS3Object.Location),
-    appiumS3Object,
+    wdOverride: TestObject.overrideWD(wd, s3Location),
+    s3Location,
     wd,
   };
 };
@@ -167,9 +168,8 @@ TestObject.enableTestObject = async function (wd, driverName, driverUrl) {
  * Takes the object that was returned by enableTestObject and uses it to restore WD
  * and delete the zip from S3
  */
-TestObject.disableTestObject = async function ({wdOverride, appiumS3Object, wd}) {
-  TestObject.restoreWD(wd, wdOverride);
-  await S3.deleteZip(appiumS3Object.Key);
+TestObject.disableTestObject = async function ({wdOverride, wd}) {
+  wd.promiseChainRemote = wdOverride;
 };
 
 TestObject.fetchAppium = async function (driverName, driverUrl) {
@@ -178,7 +178,7 @@ TestObject.fetchAppium = async function (driverName, driverUrl) {
   const pathToAppium = path.resolve(tempdir, 'appium');
   await fs.rimraf(pathToAppium);
   logger.debug('Cloning appium');
-  await exec('git', ['clone', 'git@github.com:appium/appium.git'], {cwd: tempdir});
+  await exec('git', ['clone', 'https://github.com/appium/appium.git'], {cwd: tempdir});
   logger.debug(`Cloned appium at ${tempdir}`);
 
   // Rewrite the package.json to use the branch
@@ -189,9 +189,23 @@ TestObject.fetchAppium = async function (driverName, driverUrl) {
 
   // Install node modules
   logger.debug(`Running 'npm install' at ${pathToAppium}`);
-  await exec('npm', ['install'], {cwd: pathToAppium});
-  logger.debug(`Done running 'npm install'`);
-
+  await new B((resolve, reject) => {
+    const proc = new SubProcess(process.env.APPVEYOR ? 'npm.cmd' : 'npm', ['install'], {cwd: pathToAppium});
+    proc.on('output', (stdout, stderr) => {
+      logger.debug('npm install: ', stdout);
+      logger.error('npm install: ', stderr);
+    });
+    proc.on('exit', (code) => {
+      if (code > 0) {
+        logger.error(`Could not install NPM modules. Exited with code ${code}`);
+        reject(code);
+      } else {
+        logger.debug('Done running npm install');
+        resolve(code);
+      }
+    });
+    proc.start();
+  });
   // Zip it and return it
   const pathToZip = path.resolve(tempdir, 'appium.zip');
   logger.debug(`Writing zip file to ${pathToZip}`);

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prepublish": "gulp prepublish",
     "test": "gulp once",
     "watch": "gulp watch",
-    "e2e-test": "gulp e2e-test",
+    "e2e-test": "mocha build/test/e2e/ -t 10000000",
     "build": "gulp transpile",
     "coverage": "gulp coveralls",
     "lint": "gulp eslint",

--- a/test/e2e/s3-e2e-specs.js
+++ b/test/e2e/s3-e2e-specs.js
@@ -3,8 +3,10 @@ import chaiAsPromised from 'chai-as-promised';
 import request from 'request-promise';
 import path from 'path';
 import { tempDir, fs } from 'appium-support';
-import { uploadZip, deleteZip } from '../../lib/s3';
-import B from 'bluebird';
+import { uploadZip } from '../../lib/s3';
+import sinon from 'sinon';
+import AWS from 'aws-sdk';
+import { v4 as uuid } from 'uuid';
 
 const {openDir} = tempDir;
 const {writeFile, mkdir} = fs;
@@ -13,7 +15,7 @@ chai.should();
 chai.use(chaiAsPromised);
 
 describe('S3', () => {
-  let tempDir, testDir, zipPath;
+  let tempDir, testDir, zipPath, s3UploadSpy, s3Proto;
 
   before(async () => {
     // Create a temporary directory with one file and upload it to S3
@@ -23,6 +25,12 @@ describe('S3', () => {
     const fileContents = 'Temporary file contents';
     zipPath = path.resolve(testDir, 'temp-file.zip');
     await writeFile(zipPath, fileContents);
+    s3Proto = Object.getPrototypeOf(new AWS.S3());
+    s3UploadSpy = sinon.spy(s3Proto, 'upload');
+  });
+
+  after(async () => {
+    s3UploadSpy.restore();
   });
 
   it('should zip directories and publish them to S3 and then unpublish them', async function () {
@@ -30,14 +38,22 @@ describe('S3', () => {
     if (!process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_ACCESS_KEY) {
       this.skip();
     }
-    const res = await uploadZip(zipPath);
 
-    // Download the zipped directory, unzip it, and compare it's contents to the original temporary directory
-    await request(res.Location).should.eventually.be.resolved;
+    const uniqueFileName = `git+https://github.com/fake/library${uuid()}`;
 
-    // Delete the directory from S3 and verify that it was successfully deleted
-    await deleteZip(res.key).should.eventually.be.resolved;
-    await B.delay(1000); // Give it a second for the URL to become inaccessible
-    await request(res.Location).should.eventually.be.rejectedWith(/403/);
+    s3Proto.upload.notCalled.should.be.true;
+    const location = await uploadZip(zipPath, uniqueFileName);
+
+    // Check that we can download it
+    await request(location).should.eventually.be.resolved;
+    s3Proto.upload.calledOnce.should.be.true;
+
+    // Now upload it again, this time it shouldn't call s3.upload again
+    const nextLocation = await uploadZip(zipPath, uniqueFileName);
+    s3Proto.upload.calledOnce.should.be.true;
+    s3Proto.upload.calledTwice.should.be.false;
+
+    const firstLocationContents = await request(location);
+    await request(nextLocation).should.eventually.equal(firstLocationContents);
   });
 });

--- a/test/s3-specs.js
+++ b/test/s3-specs.js
@@ -1,13 +1,16 @@
 // transpile:mocha
 /* eslint-disable promise/prefer-await-to-callbacks */
 
-import { uploadZip, deleteZip } from '../lib/s3';
+import S3 from '../lib/s3';
 
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import AWS from 'aws-sdk';
 import { fs } from 'appium-support';
+
+const {uploadZip} = S3;
+
 chai.should();
 chai.use(chaiAsPromised);
 
@@ -15,14 +18,18 @@ describe('s3', () => {
   let s3Proto = Object.getPrototypeOf(new AWS.S3());
 
   describe('uploadZip', () => {
-    let fileExistsStub, readFileStub;
+    let fileExistsStub, readFileStub, uploaderStub, s3FileExistsStub;
     beforeEach(() => {
-      fileExistsStub = sinon.stub(fs, 'exists', () => true);
-      readFileStub = sinon.stub(fs, 'readFile', () => "dummy");
+      fileExistsStub = sinon.stub(fs, 'exists');
+      readFileStub = sinon.stub(fs, 'readFile');
+      s3FileExistsStub = sinon.stub(S3, 'fileExists');
+      readFileStub.returns('dummy');
+      fileExistsStub.returns(true);
     });
     afterEach(() => {
       fileExistsStub.restore();
       readFileStub.restore();
+      s3FileExistsStub.restore();
     });
     it('should reject if AWS_S3_BUCKET not defined in env', async () => {
       const backupBucket = process.env.AWS_S3_BUCKET;
@@ -32,37 +39,52 @@ describe('s3', () => {
     });
     it('should reject if file does not exist', async () => {
       fileExistsStub.restore();
-      fileExistsStub = sinon.stub(fs, 'exists', () => false);
+      fileExistsStub.returns(false);
+      const fakeEventObject = {
+        on: () => {},
+      };
+      uploaderStub = sinon.stub(s3Proto, 'upload', ((obj, cb) => {
+        cb('Could not find');
+        return fakeEventObject;
+      }));
       await uploadZip('/fake/file/path.zip').should.eventually.be.rejectedWith(/Could not find/);
+      uploaderStub.restore();
     });
     it('should reject if s3.upload fails', async () => {
-      const uploaderStub = sinon.stub(s3Proto, 'upload', (obj, cb) => { cb(new Error('does not matter')); });
+      const fakeEventObject = {
+        on: () => {},
+      };
+      uploaderStub = sinon.stub(s3Proto, 'upload', ((obj, cb) => {
+        cb(new Error('some random S3 error'));
+        return fakeEventObject;
+      }));
       await uploadZip('/fake/file/path.zip').should.eventually.be.rejectedWith(/Could not upload/);
       uploaderStub.restore();
     });
     it('should pass if s3.upload does not fail', async () => {
-      const uploaderStub = sinon.stub(s3Proto, 'upload', (obj, cb) => { cb(null, 'Success'); });
-      await uploadZip().should.eventually.equal('Success');
+      const fakeEventObject = {
+        on: () => {},
+      };
+      uploaderStub = sinon.stub(s3Proto, 'upload', ((obj, cb) => {
+        cb(null, 'Success');
+        return fakeEventObject;
+      }));
+      s3FileExistsStub.returns(false);
+      await uploadZip('/fake/file/path.zip').should.eventually.be.resolved;
       uploaderStub.restore();
     });
-  });
+    it('should not reupload if it is cached', async () => {
+      const fakeEventObject = {
+        on: () => {},
+      };
 
-  describe('deleteZip', () => {
-    it('should reject if AWS_S3_BUCKET not defined in env', async () => {
-      const backupBucket = process.env.AWS_S3_BUCKET;
-      delete process.env.AWS_S3_BUCKET;
-      await deleteZip().should.eventually.be.rejectedWith(/AWS_S3_BUCKET/);
-      process.env.AWS_S3_BUCKET = backupBucket;
-    });
-    it('should reject if s3.deleteObject throws error', async () => {
-      const deleteObjectStub = sinon.stub(s3Proto, 'deleteObject', (obj, cb) => { cb(new Error('does not matter')); });
-      await deleteZip().should.eventually.be.rejectedWith(/Could not delete/);
-      deleteObjectStub.restore();
-    });
-    it('should resolve if s3.deleteObject does not fail', async () => {
-      const deleteObjectStub = sinon.stub(s3Proto, 'deleteObject', (obj, cb) => { cb(null, 'Success'); });
-      await deleteZip().should.eventually.equal('Success');
-      deleteObjectStub.restore();
+      // Shouldn't matter if s3.upload fails
+      uploaderStub = sinon.stub(s3Proto, 'upload', ((obj, cb) => {
+        cb(new Error('some random S3 error'));
+        return fakeEventObject;
+      }));
+      s3FileExistsStub.returns(true);
+      await uploadZip('/fake/file/path.zip').should.eventually.be.resolved;
     });
   });
 });

--- a/test/testobject-specs.js
+++ b/test/testobject-specs.js
@@ -202,35 +202,12 @@ describe('testobject-utils.js', function () {
       rimrafStub.returns(true);
       let fakeWD = {fakeWD: 'fakeWD'};
       uploadZipStub.reset();
-      uploadZipStub.returns({Location: 'HelloWorldLand', Key: 'key'});
-      overrideWDStub.throws('Incorrect parameters');
+      uploadZipStub.returns('HelloWorldLand');
       overrideWDStub.withArgs(fakeWD, 'HelloWorldLand').returns('hello world');
-      const {wdOverride, appiumS3Object, wd} = await TestObject.enableTestObject(fakeWD, '/does/not/matter');
-      appiumS3Object.should.deep.equal({
-        Location: 'HelloWorldLand',
-        Key: 'key',
-      });
+      const {wdOverride, s3Location, wd} = await TestObject.enableTestObject(fakeWD, 'fake-driver-name', 'git+https://github.com/fake/url');
+      s3Location.should.equal('HelloWorldLand');
       wd.should.deep.equal({fakeWD: 'fakeWD'});
       wdOverride.should.equal('hello world');
-    });
-  });
-  describe('#disableTestObject', function () {
-    let restoreWDStub, deleteZipStub;
-    beforeEach(async function () {
-      restoreWDStub = sinon.stub(TestObject, 'restoreWD');
-      deleteZipStub = sinon.stub(S3, 'deleteZip');
-    });
-    it('should call restoreWD and deleteZip', function () {
-      restoreWDStub.throws('invalid args');
-      deleteZipStub.throws('invalid args');
-      const wdObj = {
-        wd: 'wd',
-        wdOverride: 'wdOverride',
-        appiumS3Object: {Key: 'appiumS3ObjectKey'},
-      };
-      restoreWDStub.withArgs('wd', 'wdOverride').returns(undefined);
-      deleteZipStub.withArgs('appiumS3ObjectKey').returns(undefined);
-      TestObject.disableTestObject(wdObj).should.eventually.be.resolved;
     });
   });
 });


### PR DESCRIPTION
* Checks if file already exists prior to creating new one
* Don't re-zip and re-install new Appium if one is already saved to S3
* Use `s3.headObject` to check if file exists (much quicker than requesting the whole thing)
* Fix tests
* Use SubProcess instead of 'exec' so that we can log output to Travis
* Use git http instead of git ssh so that npm install works on Travis