### PR TITLE
Fetch appium fixes

### DIFF
--- a/lib/testobject.js
+++ b/lib/testobject.js
@@ -181,6 +181,11 @@ TestObject.fetchAppium = async function (driverName, driverUrl) {
   await exec('git', ['clone', 'https://github.com/appium/appium.git'], {cwd: tempdir});
   logger.debug(`Cloned appium at ${tempdir}`);
 
+  // Enforce 'https://' over 'git@' for driverUrl. 'git@' is unauthorized in CI.
+  if (driverUrl.indexOf('git')) {
+    logger.error(`Error in driver url: ${driverUrl}. Use https instead.`);
+  }
+
   // Rewrite the package.json to use the branch
   logger.debug(`Rewriting ${driverName} in package.json to ${driverUrl}`);
   const packageJSON = require(path.resolve(pathToAppium, 'package.json'));
@@ -213,5 +218,14 @@ TestObject.fetchAppium = async function (driverName, driverUrl) {
   await fs.rimraf(path.resolve(tempdir, 'appium'));
   return pathToZip;
 };
+
+TestObject.ANDROID_DEVICES = [
+  'HTC_One_M8_real',
+  'LG_Nexus_5x_real',
+  'Motorola_Moto_E_2nd_gen_real',
+  'Samsung_Galaxy_S6_real',
+  'Samsung_Galaxy_S7_Edge_real',
+  'Samsung_Galaxy_S8_real',
+];
 
 export default TestObject;

--- a/lib/testobject.js
+++ b/lib/testobject.js
@@ -216,7 +216,7 @@ TestObject.fetchAppium = async function (driverName, driverUrl) {
   const pathToZip = path.resolve(tempdir, 'appium.zip');
 
   //await zip(pathToZip, [pathToAppiumCopy]);
-  const pathToBestZip = path.resolve(__dirname, '..', 'node_modules', '.bin', 'bestzip');
+  const pathToBestZip = path.resolve(process.env.PWD, 'node_modules', '.bin', 'bestzip');
   logger.debug(`Running from ${pathToBestZip}`);
   await exec(pathToBestZip, [pathToZip, pathToAppiumCopy]);
   logger.debug(`Zipped Appium to ${pathToZip}`);

--- a/lib/testobject.js
+++ b/lib/testobject.js
@@ -212,10 +212,15 @@ TestObject.fetchAppium = async function (driverName, driverUrl) {
     proc.start();
   });
   // Zip it and return it
+  const pathToAppiumCopy = path.resolve(tempdir, 'appium');
   const pathToZip = path.resolve(tempdir, 'appium.zip');
-  logger.debug(`Writing zip file to ${pathToZip}`);
-  await exec('zip', ['-r', 'appium.zip', 'appium/'], {cwd: tempdir});
-  await fs.rimraf(path.resolve(tempdir, 'appium'));
+
+  //await zip(pathToZip, [pathToAppiumCopy]);
+  const pathToBestZip = path.resolve(__dirname, '..', 'node_modules', '.bin', 'bestzip');
+  logger.debug(`Running from ${pathToBestZip}`);
+  await exec(pathToBestZip, [pathToZip, pathToAppiumCopy]);
+  logger.debug(`Zipped Appium to ${pathToZip}`);
+  await fs.rimraf(pathToAppiumCopy);
   return pathToZip;
 };
 

--- a/lib/testobject.js
+++ b/lib/testobject.js
@@ -145,7 +145,8 @@ TestObject.enableTestObject = async function (wd, driverName, driverUrl, commitS
     logger.debug(`Reusing cached version of '${zipfileName}'`);
     s3Location = S3.getS3Location(zipfileName);
   } else {
-    const appiumZip = await TestObject.fetchAppium(driverName, driverUrl);
+    const gitUrl = `${driverUrl}#${commitSHA}`;
+    const appiumZip = await TestObject.fetchAppium(driverName, gitUrl);
     logger.debug(`Uploading '${appiumZip}' to S3`);
     try {
       s3Location = await S3.uploadZip(appiumZip, zipfileName);

--- a/lib/testobject.js
+++ b/lib/testobject.js
@@ -182,8 +182,8 @@ TestObject.fetchAppium = async function (driverName, driverUrl) {
   logger.debug(`Cloned appium at ${tempdir}`);
 
   // Enforce 'https://' over 'git@' for driverUrl. 'git@' is unauthorized in CI.
-  if (driverUrl.indexOf('git')) {
-    logger.error(`Error in driver url: ${driverUrl}. Use https instead.`);
+  if (driverUrl.startsWith('git@')) {
+    throw new Error(`Error in driver url: ${driverUrl}. Use https instead.`);
   }
 
   // Rewrite the package.json to use the branch
@@ -215,7 +215,7 @@ TestObject.fetchAppium = async function (driverName, driverUrl) {
   const pathToAppiumCopy = path.resolve(tempdir, 'appium');
   const pathToZip = path.resolve(tempdir, 'appium.zip');
 
-  //await zip(pathToZip, [pathToAppiumCopy]);
+  // Shell out call to 'bestzip' (bestzip is a cross-platform zip CLI)
   const pathToBestZip = path.resolve(process.env.PWD, 'node_modules', '.bin', 'bestzip');
   logger.debug(`Running from ${pathToBestZip}`);
   await exec(pathToBestZip, [pathToZip, pathToAppiumCopy]);

--- a/lib/testobject.js
+++ b/lib/testobject.js
@@ -2,9 +2,11 @@ import path from 'path';
 import S3 from './s3';
 import { exec, SubProcess } from 'teen_process';
 import { fs, tempDir } from 'appium-support';
+import { createWriteStream } from 'fs';
 import B from 'bluebird';
 import logger from '../lib/logger';
 import _ from 'lodash';
+import archiver from 'archiver';
 
 const TestObject = {};
 
@@ -136,8 +138,8 @@ TestObject.overrideWD = function (wd, appiumZipUrl) {
 /**
  * Uploads zip to S3 and overrides WD to use TO objects
  */
-TestObject.enableTestObject = async function (wd, driverName, driverUrl) {
-  const zipfileName = `${driverName}_${driverUrl}`;
+TestObject.enableTestObject = async function (wd, driverName, driverUrl, commitSHA) {
+  const zipfileName = `${driverName}_${commitSHA}`;
   let s3Location;
   if (await S3.fileExists(zipfileName)) {
     logger.debug(`Reusing cached version of '${zipfileName}'`);
@@ -215,12 +217,26 @@ TestObject.fetchAppium = async function (driverName, driverUrl) {
   const pathToAppiumCopy = path.resolve(tempdir, 'appium');
   const pathToZip = path.resolve(tempdir, 'appium.zip');
 
-  // Shell out call to 'bestzip' (bestzip is a cross-platform zip CLI)
-  const pathToBestZip = path.resolve(process.env.PWD, 'node_modules', '.bin', 'bestzip');
-  logger.debug(`Running from ${pathToBestZip}`);
-  await exec(pathToBestZip, [pathToZip, pathToAppiumCopy]);
-  logger.debug(`Zipped Appium to ${pathToZip}`);
-  await fs.rimraf(pathToAppiumCopy);
+  // Zip appium using archiver library
+  logger.debug(`Zipping ${pathToAppiumCopy} to ${pathToZip}`);
+  const output = createWriteStream(pathToZip);
+  const archive = archiver('zip');
+
+  const promise = new B((resolve, reject) => {
+    output.on('close', resolve);
+    output.on('error', reject);
+  });
+  archive.pipe(output);
+  archive.directory(pathToAppiumCopy, false);
+  archive.on('progress', (data) => {
+    if (data.entries.processed % 100 === 0) {
+      const percent = Math.round(data.entries.processed / data.entries.total * 10000) / 100;
+      logger.debug(`Zipping ${percent}%`);
+    }
+  });
+  archive.finalize();
+  await promise;
+  logger.debug(`Done zipping appium to ${pathToZip}`);
   return pathToZip;
 };
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "appium"
   ],
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": "appium",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "appium-support": "^2.5.0",
     "aws-sdk": "^2.46.0",
     "babel-runtime": "=5.8.24",
+    "bestzip": "^1.1.4",
     "bluebird": "^2.9.32",
     "lodash": "^3.10.0",
     "sinon": "^1.15.4",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   },
   "dependencies": {
     "appium-support": "^2.5.0",
+    "archiver": "^2.1.0",
     "aws-sdk": "^2.46.0",
     "babel-runtime": "=5.8.24",
-    "bestzip": "^1.1.4",
     "bluebird": "^2.9.32",
     "lodash": "^3.10.0",
     "sinon": "^1.15.4",

--- a/test/e2e/testobject-e2e-specs.js
+++ b/test/e2e/testobject-e2e-specs.js
@@ -29,7 +29,7 @@ describe('TestObject', function () {
     });
   });
 
-  describe('.enableTestObject, .disableTestObject', function () {
+  describe.only('.enableTestObject, .disableTestObject', function () {
     it('should enable testObject tests and then be able to disable them afterwards', async function () {
       const s3Proto = Object.getPrototypeOf(new AWS.S3());
       const s3UploadSpy = sinon.spy(s3Proto, 'upload');
@@ -38,7 +38,7 @@ describe('TestObject', function () {
         wd,
         'appium-uiautomator2-driver',
         'git+https://git@github.com/appium/appium-uiautomator2-driver.git',
-        'MASTER',
+        'master',
       );
       s3Proto.upload.callCount.should.be.below(2);
 

--- a/test/e2e/testobject-e2e-specs.js
+++ b/test/e2e/testobject-e2e-specs.js
@@ -38,7 +38,7 @@ describe('TestObject', function () {
         wd,
         'appium-uiautomator2-driver',
         'git+https://git@github.com/appium/appium-uiautomator2-driver.git',
-        'RANDOM_SHA',
+        'MASTER',
       );
       s3Proto.upload.callCount.should.be.below(2);
 

--- a/test/e2e/testobject-e2e-specs.js
+++ b/test/e2e/testobject-e2e-specs.js
@@ -12,7 +12,7 @@ chai.should();
 chai.use(chaiAsPromised);
 
 describe('TestObject', function () {
-  describe('#fetchAppium', function () {
+  describe('#fetchAppium @skip-ci', function () {
     it('fetches appium zip', async function () {
       const appiumZip = await fetchAppium(
         'appium-uiautomator2-driver',

--- a/test/e2e/testobject-e2e-specs.js
+++ b/test/e2e/testobject-e2e-specs.js
@@ -29,7 +29,7 @@ describe('TestObject', function () {
     });
   });
 
-  describe.only('.enableTestObject, .disableTestObject', function () {
+  describe('.enableTestObject, .disableTestObject', function () {
     it('should enable testObject tests and then be able to disable them afterwards', async function () {
       const s3Proto = Object.getPrototypeOf(new AWS.S3());
       const s3UploadSpy = sinon.spy(s3Proto, 'upload');

--- a/test/e2e/testobject-e2e-specs.js
+++ b/test/e2e/testobject-e2e-specs.js
@@ -17,7 +17,7 @@ describe('TestObject', function () {
       const appiumZip = await fetchAppium(
         'appium-uiautomator2-driver',
         'git+https://git@github.com/appium/appium-uiautomator2-driver.git',
-        'master'
+        'master',
       );
       await fs.exists(appiumZip).should.eventually.be.true;
     });
@@ -34,7 +34,12 @@ describe('TestObject', function () {
       const s3Proto = Object.getPrototypeOf(new AWS.S3());
       const s3UploadSpy = sinon.spy(s3Proto, 'upload');
       s3Proto.upload.notCalled.should.be.true;
-      const wdObject = await enableTestObject(wd, 'appium-uiautomator2-driver', 'git+https://git@github.com/appium/appium-uiautomator2-driver.git');
+      const wdObject = await enableTestObject(
+        wd,
+        'appium-uiautomator2-driver',
+        'git+https://git@github.com/appium/appium-uiautomator2-driver.git',
+        'RANDOM_SHA',
+      );
       s3Proto.upload.callCount.should.be.below(2);
 
       // Test that the zip was uploaded


### PR DESCRIPTION
* Don't allow package url's to use `git` protocol (`git@...` throws a permission denied error)
* Keep a list of Android Devices we'd like to test here (at least until we learn how to do TestObject dynamic device allocation)
* Use zip library instead of shelling to native zip so that it works on Windows (I'd like to try using AppVeyor to run our TestObject tests)