### PR TITLE
Fix handling of mocks and verification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,5 @@ node_js:
 after_success:
   - npm run coverage
 script:
-  - npm run build
   - npm test
   - npm run e2e-test

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ describe('MyTest', withSandbox({mocks: {api}}, (S) => {
 When using mainly stubs.
 
 ```js
-import { withMocks, verify } from 'appium-test-support';
+import { withMocks } from 'appium-test-support';
 
 let api = {
   abc: () => { return 'abc'; }
@@ -96,15 +96,7 @@ describe('withMocks', withMocks({api}, (mocks) => {
   it('should mock api', () => {
     mocks.api.expects('abc').once().returns('efg');
     api.abc().should.equal('efg');
-    verify(mocks);
-  });
-}));
-
-describe('withMocks (+S)', withMocks({api}, (mocks, S) => {
-  it('should mock api (+S)', () => {
-    mocks.api.expects('abc').once().returns('efg');
-    api.abc().should.equal('efg');
-    S.verify();
+    mocks.verify();
   });
 }));
 ```

--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
-import { stubEnv } from './lib/env-utils.js';
-import { stubLog } from './lib/log-utils.js';
-import { fakeTime } from './lib/time-utils.js';
-import { withSandbox, withMocks, verify } from './lib/sandox-utils.js';
-import { enableTestObject, disableTestObject } from './lib/testobject.js';
+import { stubEnv } from './lib/env-utils';
+import { stubLog } from './lib/log-utils';
+import { fakeTime } from './lib/time-utils';
+import { withMocks, verifyMocks } from './lib/mock-utils';
+import { withSandbox, verifySandbox } from './lib/sandox-utils';
+import { enableTestObject, disableTestObject } from './lib/testobject';
 
-export { stubEnv, stubLog, fakeTime, withSandbox, withMocks, verify,
-  enableTestObject, disableTestObject };
+export { stubEnv, stubLog, fakeTime, withSandbox, verifySandbox, withMocks,
+         verifyMocks, enableTestObject, disableTestObject };

--- a/lib/env-utils.js
+++ b/lib/env-utils.js
@@ -2,8 +2,12 @@ import _ from 'lodash';
 
 function stubEnv () {
   let envBackup;
-  beforeEach(() => { envBackup = process.env; process.env = _.cloneDeep(process.env); });
-  afterEach(() => { process.env = envBackup; });
+  beforeEach(function () {
+    envBackup = process.env; process.env = _.cloneDeep(process.env);
+  });
+  afterEach(function () {
+    process.env = envBackup;
+  });
 }
 
 export { stubEnv };

--- a/lib/log-utils.js
+++ b/lib/log-utils.js
@@ -24,7 +24,9 @@ class LogStub {
 function stubLog (sandbox, log, opts={}) {
   let logStub = new LogStub(opts);
   for (let l of log.levels) {
-    sandbox.stub(log, l, (mess) => { logStub.log(l, mess); });
+    sandbox.stub(log, l).callsFake(function (mess) {
+      logStub.log(l, mess);
+    });
   }
   return logStub;
 }

--- a/lib/mock-utils.js
+++ b/lib/mock-utils.js
@@ -5,28 +5,32 @@ let SANDBOX = Symbol();
 
 function withMocks (libs, fn) {
   return () => {
-    let sandbox;
-    let mocks = {};
-    beforeEach(() => {
-      sandbox = sinon.sandbox.create();
-      mocks[SANDBOX] = sandbox;
-      for (let [key, value] of _.pairs(libs)) {
-        mocks[key] = sandbox.mock(value);
+    const mocks = {
+      verify () {
+        this.sandbox.verify();
+      },
+      get sandbox () {
+        return this[SANDBOX];
+      },
+      set sandbox (sandbox) {
+        this[SANDBOX] = sandbox;
+      },
+    };
+    beforeEach(function () {
+      mocks[SANDBOX] = sinon.sandbox.create();
+      for (let [key, value] of _.toPairs(libs)) {
+        mocks[key] = mocks.sandbox.mock(value);
       }
     });
-    afterEach(() => {
-      sandbox.restore();
+    afterEach(function () {
+      mocks.sandbox.restore();
     });
     fn(mocks);
   };
 }
 
-function verifyAll (mocks) {
-  mocks[SANDBOX].verify();
+function verifyMocks (mocks) {
+  mocks.sandbox.verify();
 }
 
-function getSandbox (mocks) {
-  return mocks[SANDBOX];
-}
-
-export { withMocks, verifyAll, getSandbox };
+export { withMocks, verifyMocks };

--- a/lib/sandox-utils.js
+++ b/lib/sandox-utils.js
@@ -6,20 +6,20 @@ let SANDBOX = Symbol();
 // use this one if using a mix of mocks/stub/spies
 function withSandbox (config, fn) {
   return () => {
-    let S = {
+    const S = {
       mocks: {},
       verify () {
         return this.sandbox.verify();
-      }
+      },
     };
-    beforeEach(() => {
+    beforeEach(function () {
       S.sandbox = sinon.sandbox.create();
       S.mocks[SANDBOX] = S.sandbox;
-      for (let [key, value] of _.pairs(config.mocks)) {
+      for (let [key, value] of _.toPairs(config.mocks)) {
         S.mocks[key] = S.sandbox.mock(value);
       }
     });
-    afterEach(() => {
+    afterEach(function () {
       S.sandbox.restore();
       for (let k of _.keys(S.mocks)) {
         delete S.mocks[k];
@@ -30,16 +30,9 @@ function withSandbox (config, fn) {
   };
 }
 
-// use this if using only mocks
-function withMocks (libs, fn) {
-  return withSandbox({mocks: libs}, function (S) {
-    fn(S.mocks, S);
-  });
-}
-
-function verify (obj) {
+function verifySandbox (obj) {
   let sandbox = obj.sandbox ? obj.sandbox : obj[SANDBOX];
   sandbox.verify();
 }
 
-export { withSandbox, withMocks, verify };
+export { withSandbox, verifySandbox };

--- a/lib/testobject.js
+++ b/lib/testobject.js
@@ -198,13 +198,15 @@ TestObject.fetchAppium = async function (driverName, driverUrl) {
   logger.debug(`Running 'npm install' at ${pathToAppium}`);
   await new B((resolve, reject) => {
     const proc = new SubProcess(process.env.APPVEYOR ? 'npm.cmd' : 'npm', ['install'], {cwd: pathToAppium});
-    proc.on('output', (stdout, stderr) => {
-      logger.debug('npm install: ', stdout);
-      logger.error('npm install: ', stderr);
+    proc.on('lines-stdout', (stdout) => {
+      logger.debug(`[npm] ${stdout}`);
+    });
+    proc.on('lines-stderr', (stderr) => {
+      logger.error(`[npm] ${stderr}`);
     });
     proc.on('exit', (code) => {
       if (code > 0) {
-        logger.error(`Could not install NPM modules. Exited with code ${code}`);
+        logger.error(`Could not install npm modules. Exited with code ${code}`);
         reject(code);
       } else {
         logger.debug('Done running npm install');
@@ -236,7 +238,7 @@ TestObject.fetchAppium = async function (driverName, driverUrl) {
   archive.pipe(output);
   archive.directory(pathToAppiumCopy, false);
   archive.on('progress', (data) => {
-    if (data.entries.processed % 100 === 0) {
+    if (data.entries.processed % 10000 === 0) {
       const percent = Math.round(data.entries.processed / data.entries.total * 10000) / 100;
       logger.debug(`Zipping ${percent}%`);
     }

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
     "archiver": "^2.1.0",
     "aws-sdk": "^2.46.0",
     "babel-runtime": "=5.8.24",
-    "bluebird": "^2.9.32",
-    "lodash": "^3.10.0",
-    "sinon": "^1.15.4",
-    "source-map-support": "^0.3.1",
+    "bluebird": "^3.5.1",
+    "lodash": "^4.17.5",
+    "sinon": "^4.5.0",
+    "source-map-support": "^0.5.4",
     "uuid": "^3.0.1"
   },
   "scripts": {
@@ -52,11 +52,11 @@
     "test"
   ],
   "devDependencies": {
-    "appium": "^1.6.5",
+    "appium": "^1.7.2",
     "appium-gulp-plugins": "^2.2.2",
     "babel-eslint": "^7.1.1",
-    "chai": "^3.0.0",
-    "chai-as-promised": "^5.1.0",
+    "chai": "^4.1.2",
+    "chai-as-promised": "^7.1.1",
     "colors": "^1.1.2",
     "eslint": "^3.10.2",
     "eslint-config-appium": "^2.0.1",
@@ -65,7 +65,7 @@
     "eslint-plugin-mocha": "^4.7.0",
     "eslint-plugin-promise": "^3.3.1",
     "gulp": "^3.8.11",
-    "mocha": "^3.5.0",
+    "mocha": "^5.0.5",
     "mock-fs": "^4.4.1",
     "pre-commit": "^1.2.2",
     "request-promise": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prepublish": "gulp prepublish",
     "test": "gulp once",
     "watch": "gulp watch",
-    "e2e-test": "mocha build/test/e2e/ -t 10000000",
+    "e2e-test": "gulp transpile && mocha build/test/e2e/ -t 10000000",
     "build": "gulp transpile",
     "coverage": "gulp coveralls",
     "lint": "gulp eslint",

--- a/test/e2e/s3-e2e-specs.js
+++ b/test/e2e/s3-e2e-specs.js
@@ -45,7 +45,7 @@ describe('S3', function () {
     const location = await uploadZip(zipPath, uniqueFileName);
 
     // Check that we can download it
-    await request(location).should.eventually.be.resolved;
+    await request(location).should.eventually.not.be.rejected;
     s3Proto.upload.calledOnce.should.be.true;
 
     // Now upload it again, this time it shouldn't call s3.upload again

--- a/test/e2e/testobject-e2e-specs.js
+++ b/test/e2e/testobject-e2e-specs.js
@@ -25,7 +25,8 @@ describe('TestObject', function () {
 
   describe('#uploadTestObjectApp', function () {
     it('should upload fake app file to testObject', async function () {
-      await uploadTestObjectApp(path.resolve('test', 'fixtures', 'ContactManager.apk')).should.eventually.be.resolved;
+      await uploadTestObjectApp(path.resolve('test', 'fixtures', 'ContactManager.apk'))
+        .should.eventually.not.be.rejected;
     });
   });
 
@@ -44,7 +45,7 @@ describe('TestObject', function () {
 
       // Test that the zip was uploaded
       const location = wdObject.s3Location;
-      await request(location).should.eventually.be.resolved;
+      await request(location).should.eventually.not.be.rejected;
 
       // Test that we can do TestObject tests
       const driver = await wd.promiseChainRemote();

--- a/test/env-utils-specs.js
+++ b/test/env-utils-specs.js
@@ -1,6 +1,6 @@
 // transpile:mocha
 
-import {stubEnv} from '..';
+import { stubEnv } from '..';
 import chai from 'chai';
 
 
@@ -20,4 +20,3 @@ describe('env-utils', function () {
     });
   });
 });
-

--- a/test/s3-specs.js
+++ b/test/s3-specs.js
@@ -41,50 +41,50 @@ describe('s3', function () {
       fileExistsStub.restore();
       fileExistsStub.returns(false);
       const fakeEventObject = {
-        on: () => {},
+        on () {},
       };
-      uploaderStub = sinon.stub(s3Proto, 'upload', ((obj, cb) => {
+      uploaderStub = sinon.stub(s3Proto, 'upload').callsFake(function (obj, cb) {
         cb('Could not find');
         return fakeEventObject;
-      }));
+      });
       await uploadZip('/fake/file/path.zip').should.eventually.be.rejectedWith(/Could not find/);
       uploaderStub.restore();
     });
     it('should reject if s3.upload fails', async function () {
       const fakeEventObject = {
-        on: () => {},
+        on () {},
       };
-      uploaderStub = sinon.stub(s3Proto, 'upload', ((obj, cb) => {
+      uploaderStub = sinon.stub(s3Proto, 'upload').callsFake(function (obj, cb) {
         cb(new Error('some random S3 error'));
         return fakeEventObject;
-      }));
+      });
       await uploadZip('/fake/file/path.zip').should.eventually.be.rejectedWith(/Could not upload/);
       uploaderStub.restore();
     });
     it('should pass if s3.upload does not fail', async function () {
       const fakeEventObject = {
-        on: () => {},
+        on () {},
       };
-      uploaderStub = sinon.stub(s3Proto, 'upload', ((obj, cb) => {
+      uploaderStub = sinon.stub(s3Proto, 'upload').callsFake(function (obj, cb) {
         cb(null, 'Success');
         return fakeEventObject;
-      }));
+      });
       s3FileExistsStub.returns(false);
-      await uploadZip('/fake/file/path.zip').should.eventually.be.resolved;
+      await uploadZip('/fake/file/path.zip').should.eventually.not.be.rejected;
       uploaderStub.restore();
     });
     it('should not reupload if it is cached', async function () {
       const fakeEventObject = {
-        on: () => {},
+        on () {},
       };
 
       // Shouldn't matter if s3.upload fails
-      uploaderStub = sinon.stub(s3Proto, 'upload', ((obj, cb) => {
+      uploaderStub = sinon.stub(s3Proto, 'upload').callsFake(function (obj, cb) {
         cb(new Error('some random S3 error'));
         return fakeEventObject;
-      }));
+      });
       s3FileExistsStub.returns(true);
-      await uploadZip('/fake/file/path.zip').should.eventually.be.resolved;
+      await uploadZip('/fake/file/path.zip').should.eventually.not.be.rejected;
     });
   });
 });

--- a/test/sandbox-utils-specs.js
+++ b/test/sandbox-utils-specs.js
@@ -1,6 +1,6 @@
 // transpile:mocha
 
-import { withSandbox, withMocks, verify } from '..';
+import { withSandbox, verifySandbox } from '..';
 import chai from 'chai';
 
 
@@ -34,34 +34,14 @@ describe('sandbox-utils', function () {
       S.verify();
     });
 
-    it('verify', function () {
+    it('verifySandbox', function () {
       expect(S.sandbox).to.exist;
       expect(S.mocks.funcs).to.exist;
       S.mocks.funcs.expects('abc').once().returns('efg');
       funcs.abc().should.equal('efg');
-      verify(S);
+      verifySandbox(S);
     });
 
 
-  }));
-
-  describe('withMocks', withMocks({funcs}, (mocks, S) => {
-    it('should create sandox and mocks', function () {
-      expect(mocks).to.exist;
-      expect(S).to.exist;
-      funcs.abc().should.equal('abc');
-      mocks.funcs.expects('abc').once().returns('efg');
-      funcs.abc().should.equal('efg');
-      S.sandbox.verify();
-    });
-    it('verify', function () {
-      expect(S.sandbox).to.exist;
-      expect(S.mocks.funcs).to.exist;
-      funcs.abc().should.equal('abc');
-      mocks.funcs.expects('abc').once().returns('efg');
-      funcs.abc().should.equal('efg');
-      verify(mocks);
-    });
   }));
 });
-


### PR DESCRIPTION
Currently mock usage (with `withMocks`) is weird. Because of the mocha lifecycle, the following will work:

```js
import { withMocks, verify } from 'appium-test-support';
import { fs } from 'appium-support';


describe('outer', withMocks({fs}, function (mocks) {
  describe('inner', function () {
    afterEach(function () {
      verify(mocks);
    });
    it('should do something', function () {
      mocks.fs.expects('something');
    });
  });
}));
```

while the following fails because `mocks[SANDBOX]` has already been deleted

```js
describe('outer', withMocks({fs}, function (mocks) {
  afterEach(function () {
    // fails here because the Sandbox `afterEach` has already run
    verify(mocks);
  });
  it('should do something', function () {
    mocks.fs.expects('something');
  });
}));
```

So in order to not need nested `describe` blocks, this PR moves to an implementation we already have for `withMocks` which does not work in the broken way.

Also add a method to verify the mocks, on the `mocks` object, for simplicity. Now we can do:
```js
describe('outer', withMocks({fs}, function (mocks) {
  afterEach(function () {
    mocks.verify();
  });
  it('should do something', function () {
    mocks.fs.expects('something');
  });
}));
```

This is a **breaking change** that will necessitate a major release of the package.

[Where is the package used?].