### PR TITLE
Update appium-gulp-plugins

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-node_modules
-*.log
-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: required
 language: node_js
 node_js:
-  - "6"
-  - "7"
+  - "8"
+  - "10"
 after_success:
   - npm run coverage
 script:

--- a/index.js
+++ b/index.js
@@ -4,5 +4,7 @@ import { fakeTime } from './lib/time-utils';
 import { withMocks, verifyMocks } from './lib/mock-utils';
 import { withSandbox, verifySandbox } from './lib/sandox-utils';
 
-export { stubEnv, stubLog, fakeTime, withSandbox, verifySandbox, withMocks,
-         verifyMocks };
+
+export {
+  stubEnv, stubLog, fakeTime, withSandbox, verifySandbox, withMocks, verifyMocks
+};

--- a/lib/log-utils.js
+++ b/lib/log-utils.js
@@ -1,12 +1,12 @@
 // TODO move that to appium-support
 function stripColors (msg) {
-  let code = /\u001b\[(\d+(;\d+)*)?m/g;
+  let code = /\u001b\[(\d+(;\d+)*)?m/g; // eslint-disable-line no-control-regex
   msg = ('' + msg).replace(code, '');
   return msg;
 }
 
 class LogStub {
-  constructor (opts={}) {
+  constructor (opts = {}) {
     this.output = "";
     this.stripColors = opts.stripColors;
   }
@@ -21,7 +21,7 @@ class LogStub {
   }
 }
 
-function stubLog (sandbox, log, opts={}) {
+function stubLog (sandbox, log, opts = {}) {
   let logStub = new LogStub(opts);
   for (let l of log.levels) {
     sandbox.stub(log, l).callsFake(function (mess) {

--- a/package.json
+++ b/package.json
@@ -25,15 +25,24 @@
   "directories": {
     "lib": "lib"
   },
+  "files": [
+    "index.js",
+    "bin",
+    "lib",
+    "build/index.js",
+    "build/lib"
+  ],
   "dependencies": {
+    "@babel/runtime": "^7.0.0",
     "appium-support": "^2.5.0",
-    "babel-runtime": "=5.8.24",
     "bluebird": "^3.5.1",
     "lodash": "^4.17.5",
-    "sinon": "^6.0.0"
+    "sinon": "^6.0.0",
+    "source-map-support": "^0.5.9"
   },
   "scripts": {
-    "prepublish": "gulp prepublish",
+    "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
+    "prepare": "gulp prepublish",
     "test": "gulp once",
     "watch": "gulp watch",
     "e2e-test": "gulp transpile && mocha build/test/e2e/ -t 10000000",
@@ -48,31 +57,21 @@
     "test"
   ],
   "devDependencies": {
-    "appium-gulp-plugins": "^2.2.2",
-    "babel-eslint": "^7.1.1",
+    "ajv": "^6.5.3",
+    "appium-gulp-plugins": "^3.1.0",
+    "babel-eslint": "^10.0.0",
     "chai": "^4.1.2",
     "colors": "^1.1.2",
-    "eslint": "^3.10.2",
-    "eslint-config-appium": "^2.0.1",
-    "eslint-plugin-babel": "^3.3.0",
+    "eslint": "^5.2.0",
+    "eslint-config-appium": "^3.1.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-mocha": "^4.7.0",
-    "eslint-plugin-promise": "^3.3.1",
-    "gulp": "^3.8.11",
+    "eslint-plugin-mocha": "^5.0.0",
+    "eslint-plugin-promise": "^4.0.0",
+    "gulp": "^4.0.0",
     "mocha": "^5.0.5",
     "pre-commit": "^1.2.2"
   },
   "greenkeeper": {
-    "ignore": [
-      "babel-eslint",
-      "babel-preset-env",
-      "eslint",
-      "eslint-plugin-babel",
-      "eslint-plugin-import",
-      "eslint-plugin-mocha",
-      "eslint-plugin-promise",
-      "gulp",
-      "babel-runtime"
-    ]
+    "ignore": []
   }
 }


### PR DESCRIPTION
This PR does two main things:
1. Updates `eslint-config-appium` and fixes any linting errors.
1. Updated `appium-gulp-plugins` and moves to Babel 7 and Gulp 4.

See https://github.com/appium/appium-gulp-plugins/pull/35 for more details.