### PR TITLE
Turn on unhandled promise rejection handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ import { fakeTime } from './lib/time-utils';
 import { withMocks, verifyMocks } from './lib/mock-utils';
 import { withSandbox, verifySandbox } from './lib/sandbox-utils';
 
+// this just needs to be imported, for the functionality to be injected
+import './lib/unhandled-rejection';
 
 export {
   stubEnv, stubLog, fakeTime, withSandbox, verifySandbox, withMocks, verifyMocks

--- a/lib/unhandled-rejection.js
+++ b/lib/unhandled-rejection.js
@@ -1,0 +1,8 @@
+import loudRejection from 'loud-rejection';
+
+
+// in a testing environment (environment variable is set in `appium-gulp-utils`)
+// make sure unhandled promise rejections are made visible
+if (process.env._TESTING) {
+  loudRejection();
+}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "appium-support": "^2.5.0",
     "bluebird": "^3.5.1",
     "lodash": "^4.17.5",
+    "loud-rejection": "^1.6.0",
     "sinon": "^6.0.0",
     "source-map-support": "^0.5.9"
   },


### PR DESCRIPTION
When running our tests this will make things fail when we don't handle promise rejections, rather than printing out a little blurb about this being, in the near future, catastrophic.