### PR TITLE
Make emulator startup timeout configurable

### DIFF
--- a/bin/android-emu-travis-post.sh
+++ b/bin/android-emu-travis-post.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+: ${EMU_STARTUP_TIMEOUT:=360}
+
 if [ ${START_EMU} = "1" ]; then
     # Fail fast if emulator process cannot start
     pgrep -nf avd || exit 1
@@ -7,8 +9,7 @@ if [ ${START_EMU} = "1" ]; then
     # make sure the emulator is ready
     adb wait-for-device get-serialno
     secondsStarted=`date +%s`
-    TIMEOUT=360
-    while [[ $(( `date +%s` - $secondsStarted )) -lt $TIMEOUT ]]; do
+    while [[ $(( `date +%s` - $secondsStarted )) -lt $EMU_STARTUP_TIMEOUT ]]; do
         processList=`adb shell ps`
         if [[ "$processList" =~ "com.android.systemui" ]]; then
             echo "System UI process is running. Checking IME services availability"
@@ -16,10 +17,14 @@ if [ ${START_EMU} = "1" ]; then
         fi
         sleep 5
         secondsElapsed=$(( `date +%s` - $secondsStarted ))
-        secondsLeft=$(( $TIMEOUT - $secondsElapsed ))
+        secondsLeft=$(( $EMU_STARTUP_TIMEOUT - $secondsElapsed ))
         echo "Waiting until emulator finishes services startup; ${secondsElapsed}s elapsed; ${secondsLeft}s left"
     done
     bootDuration=$(( `date +%s` - $secondsStarted ))
+    if [[ $bootDuration -ge $EMU_STARTUP_TIMEOUT ]]; then
+        echo "Emulator has failed to fully start within ${EMU_STARTUP_TIMEOUT}s"
+        exit 1
+    fi
     echo "Emulator booting took ${bootDuration}s"
 
     adb shell input keyevent 82


### PR DESCRIPTION
Emulator startup on Travis can take up to 20 minutes in some cases: https://medium.com/@nocnoc/android-emulators-in-thcloud-f39e11c15bfa